### PR TITLE
v1.0.12

### DIFF
--- a/console/DeviceHelper.cs
+++ b/console/DeviceHelper.cs
@@ -3,25 +3,136 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace ImageDB
 {
     public static class DeviceHelper
     {
-        /// Device Helper Class
-        /// Normalizes device make and model strings
+        ///<summary>
+        /// DeviceHelper: Normalizes camera/device maker and model strings into 
+        /// a consistent, human-friendly Device name used to populate de device field.
+        /// (e.g., combine/normalize Make + Model into "Apple iPhone 11 Pro Max" or "Canon PowerShot G7").
         /// Ref: https://www.exiftool.org/models.html
         /// Ref: https://exiftool.org/sample_images.html
+        ///</summary>
 
-        // To run RunTest, uncomment the line below in the Main method of Program.cs
+        /// To run RunTest, uncomment the line below in the Main method of Program.cs
 
         public static void RunTest()
         {
             Console.WriteLine("[TEST] - Device Helper");
             Console.WriteLine("----------------------");
 
-            // Test cases for device make and model
-            Dictionary<string, string> DeviceTestSet = new Dictionary<string, string>
+            string csvPath = "Sample_DeviceList.csv";
+            Dictionary<string, string> DeviceTestSet = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (File.Exists(csvPath))
+            {
+                try
+                {
+                    var lines = File.ReadAllLines(csvPath);
+                    int lineIndex = 0;
+                    foreach (var rawLine in lines)
+                    {
+                        lineIndex++;
+                        if (string.IsNullOrWhiteSpace(rawLine)) continue;
+
+                        // If first non-empty line looks like a header, skip it
+                        if (lineIndex == 1)
+                        {
+                            var header = rawLine.Trim();
+                            if (header.IndexOf("make", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                header.IndexOf("model", StringComparison.OrdinalIgnoreCase) >= 0)
+                            {
+                                continue;
+                            }
+                        }
+
+                        // Simple CSV parsing: handle quoted fields and commas inside quotes
+                        List<string> fields = new List<string>();
+                        bool inQuotes = false;
+                        var sb = new System.Text.StringBuilder();
+                        for (int i = 0; i < rawLine.Length; i++)
+                        {
+                            char c = rawLine[i];
+                            if (c == '"' )
+                            {
+                                // Toggle quotes unless it's an escaped double quote ("")
+                                if (inQuotes && i + 1 < rawLine.Length && rawLine[i + 1] == '"')
+                                {
+                                    sb.Append('"');
+                                    i++; // skip escaped quote
+                                }
+                                else
+                                {
+                                    inQuotes = !inQuotes;
+                                }
+                            }
+                            else if (c == ',' && !inQuotes)
+                            {
+                                fields.Add(sb.ToString());
+                                sb.Clear();
+                            }
+                            else
+                            {
+                                sb.Append(c);
+                            }
+                        }
+                        fields.Add(sb.ToString());
+
+                        // Normalize fields: trim and remove surrounding quotes
+                        for (int f = 0; f < fields.Count; f++)
+                        {
+                            var s = fields[f].Trim();
+                            if (s.Length >= 2 && s.StartsWith("\"") && s.EndsWith("\""))
+                            {
+                                s = s.Substring(1, s.Length - 2).Replace("\"\"", "\"");
+                            }
+                            fields[f] = s.Trim();
+                        }
+
+                        if (fields.Count == 0) continue;
+
+                        string maker = fields[0];
+                        string model = string.Empty;
+                        if (fields.Count >= 2)
+                        {
+                            // Join remaining fields as model (handles stray commas)
+                            model = string.Join(",", fields.Skip(1)).Trim();
+                        }
+
+                        // Add to test set (avoid duplicates)
+                        if (!DeviceTestSet.ContainsKey(maker))
+                        {
+                            DeviceTestSet.Add(maker, model);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Failed to read or parse CSV file: " + ex.Message);
+                    Console.WriteLine("Falling back to embedded test data.");
+                    DeviceTestSet = GetDefaultTestSet();
+                }
+            }
+            else
+            {
+                Console.WriteLine($"CSV file '{csvPath}' not found. Using embedded test data.");
+                DeviceTestSet = GetDefaultTestSet();
+            }
+
+            foreach (var device in DeviceTestSet)
+            {
+                Console.WriteLine(device.Key + " " + device.Value + " -> " + GetDevice(device.Key, device.Value));
+            }
+            Console.WriteLine("----------------------");
+        }
+
+        // Fallback default test set (original hard-coded values)
+        private static Dictionary<string, string> GetDefaultTestSet()
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "Allied Vision Technologies", "GT3300C (02-2623A)" },
                 { "Apple", "iPhone 11 Pro Max" },
@@ -35,167 +146,351 @@ namespace ImageDB
                 { "RICOH", "RICOH THETA SC2" },
                 { "SAMSUNG", "SAMSUNG-SGH-I337" }
             };
-            foreach (var device in DeviceTestSet)
-            {
-                Console.WriteLine(device.Key + " "+device.Value+" -> "+GetDevice(device.Key, device.Value));
-            }
-            Console.WriteLine("----------------------");
         }
 
         // Dictionary to map camera makers to their normalized names
         private static readonly Dictionary<string, string> CameraMakerMap = new(StringComparer.OrdinalIgnoreCase)
         {
+            { "ACER", "Acer" },
+            { "AGFA", "Agfa" },
+            { "AGFA GEVAERT", "Agfa-Gevaert" },
+            { "AGFAPHOTO", "AgfaPhoto" },
+            { "AIPTEK", "AIPTEK" },
+            { "AKASO", "Akaso" },
+            { "APPLE", "Apple" },
+            { "ARRI", "ARRI" },
+            { "ASUS", "Asus" },
+            { "BBK IMAGING", "BBK Imaging" },
+            { "BELL & HOWELL", "Bell & Howell" },
+            { "BENQ", "BenQ" },
+            { "BLACKBERRY", "BlackBerry" },
+            { "BLACKMAGIC DESIGN", "Blackmagic Design" },
+            { "BUSHNELL", "Bushnell" },
+            { "CAMERA", "Camera" },
             { "CANON", "Canon" },
-            { "NIKON", "Nikon" },
-            { "SONY", "Sony" },
+            { "CASIO", "Casio" },
+            { "CONCORD", "Concord" },
+            { "DELL", "Dell" },
+            { "DIGILIFE", "DigiLife" },
+            { "DJI", "DJI" },
+            { "DOCOMO", "DoCoMo" },
+            { "DS GLOBAL", "DS Global" },
+            { "DXG", "DGX" },
+            { "EPSON", "Epson" },
+            { "FLIR", "FLIR" },
             { "FUJIFILM", "Fujifilm" },
-            { "PANASONIC", "Panasonic" },
+            { "FUJITSU", "Fujitsu" },
+            { "GARMIN", "Garmin" },
+            { "GEDSC", "GEDSC" },
+            { "GENERAL IMAGING", "General Imaging" },
+            { "GENIUS", "Genius" },
+            { "GOPRO", "GoPro" },
+            { "GOOGLE", "Google" },
+            { "GRANDTECH", "GrandTech" },
+            { "HASSELBLAD", "Hasselblad" },
+            { "HEWLETT-PACKARD", "HP" },
+            { "HITACHI", "Hitachi" },
+            { "HOLGA", "Holga" },
+            { "HONOR", "Honor" },
+            { "HP", "HP" },
+            { "HUAWEI", "Huawei" },
+            { "IKONOSKOP", "Ikonoskop" },
+            { "INSTA360", "Insta360" },
+            { "IQOO", "iQOO" },
+            { "JENOPTIK", "Jenoptik" },
+            { "KDDI-CA", "KDDI" },
+            { "KINEFINITY", "Kinefinity" },
+            { "KODAK", "Kodak" },
+            { "KONICA MINOLTA", "Konica Minolta" },
+            { "KONICA", "Konica" }, 
+            { "KYOCERA", "Kyocera" },
+            { "LEICA", "Leica" },
+            { "LENOVO", "Lenovo" },
+            { "LG", "LG" },
+            { "LG CYON", "LG Cyon" },
+            { "LOGITECH", "Logitech" },
+            { "LOMOGRAPHY", "Lomography" },
+            { "LUMICRON", "Lumicron" },
+            { "MAGION", "Magion" },
+            { "MEDION", "Medion" },
+            { "MEIKE", "Meike" },
+            { "MINOLTA", "Minolta" },
+            { "MITAC", "MiTAC" },
+            { "MOTO", "Moto" },
+            { "MOTOROLA", "Motorola" },
+            { "MOULTRIE", "Moultrie" },
+            { "NEXTBASE", "Nextbase" },
+            { "NIKON", "Nikon" },
+            { "NINTENDO", "Nintendo" },
+            { "NOKIA", "Nokia" },
+            { "NORITSU KOKI", "Noritsu Koki" },
+            { "ODYS", "Odys" },
             { "OLYMPUS", "Olympus" },
             { "OM SYSTEM", "OM System" },
-            { "LEICA", "Leica" },
-            { "PENTAX", "Pentax" },
-            { "RICOH", "Ricoh" },
-            { "KODAK", "Kodak" },
-            { "CASIO", "Casio" },
-            { "SAMSUNG", "Samsung" },
-            { "SIGMA", "Sigma" },
-            { "HASSELBLAD", "Hasselblad" },
-            { "GOPRO", "GoPro" },
-            { "DJI", "DJI" },
-            { "PHASE ONE", "Phase One" },
-            { "APPLE", "Apple" },
-            { "GOOGLE", "Google" },
-            { "HUAWEI", "Huawei" },
-            { "XIAOMI", "Xiaomi" },
+            { "OMG LIFE", "OMG Life" },
             { "ONEPLUS", "OnePlus" },
-            { "LOGITECH", "OnePlus" },
-            { "BLACKMAGIC DESIGN", "Blackmagic Design" },
-            { "RED DIGITAL CINEMA", "RED Digital Cinema" },
-            { "SHARP", "Sharp" },
-            { "VIVITAR", "Vivitar" },
-            { "YASHICA", "Yashica" },
-            { "BELL & HOWELL", "Bell & Howell" },
-            { "TAMRON", "Tamron" },
-            { "TOKINA", "Tokina" },
-            { "HOLGA", "Holga" },
-            { "POLAROID", "Polaroid" },
-            { "AGFAPHOTO", "AgfaPhoto" },
-            { "AGFA", "Agfa" },
-            { "LOMOGRAPHY", "Lomography" },
-            { "MEIKE", "Meike" },
-            { "SJCAM", "SJCAM" },
-            { "AKASO", "Akaso" },
-            { "INSTA360", "Insta360" },
-            { "Z CAM", "Z CAM" },
-            { "IKONOSKOP", "Ikonoskop" },
-            { "ARRI", "ARRI" },
-            { "KINEFINITY", "Kinefinity" },
-            { "ZEISS", "Zeiss" },
-            { "ROLLEI", "Rollei" },
-            { "THINKWARE", "Thinkware" },
-            { "NEXTBASE", "Nextbase" },
-            { "GARMIN", "Garmin" },
+            { "PANASONIC", "Panasonic" },
+            { "PANTECH", "Pantech" },
             { "PAPAGO", "Papago" },
+            { "PARROT", "Parrot" },
+            { "PENTACON", "Pentacon" },
+            { "PENTAX", "Pentax" },
+            { "PHASE ONE", "Phase One" },
+            { "PIONEER", "Pioneer" },
+            { "POLAROID", "Polaroid" },
+            { "PRAKTICA", "Praktica" },
+            { "REALME", "Realme" },
+            { "RED DIGITAL CINEMA", "RED Digital Cinema" },
+            { "RECONYX", "Reconyx" },
+            { "RICOH", "Ricoh" },
+            { "ROLLEI", "Rollei" },
+            { "SAMSUNG", "Samsung" },
+            { "SANYO", "Sanyo" },
+            { "SEGA", "Sega" },
+            { "SHARP", "Sharp" },
+            { "SIGMA", "Sigma" },
+            { "SIPIX", "SiPix" },
+            { "SJCAM", "SJCAM" },
+            { "SKANHEX", "Skanhex" },
+            { "SONY ERICSSON", "Sony Ericsson" },
+            { "SONY", "Sony" },
+            { "SPECTRUM IMAGING", "Spectrum Imaging" },
+            { "TAMRON", "Tamron" },
+            { "THINKWARE", "Thinkware" },
+            { "TOKINA", "Tokina" },
+            { "TOSHIBA", "Toshiba" },
+            { "TRAVELER OPTICAL", "Traveler Optical" },
             { "VIOFO", "Viofo" },
-            { "NORITSU KOKI", "Noritsu Koki" },
-            { "MOTO", "Moto" }
+            { "VIVO", "Vivo" },
+            { "VIVAX", "Vivax" },
+            { "VIVITAR", "Vivitar" },
+            { "VODAFONE", "Vodafone" },
+            { "VTECH", "VTech" },
+            { "WWL", "WWL" },
+            { "XIAOMI", "Xiaomi" },
+            { "XIAOYI", "Xiaoyi" },
+            { "YAKUMO", "Yakumo" },
+            { "YASHICA", "Yashica" },
+            { "Z CAM", "Z CAM" },
+            { "ZEISS", "Zeiss" }
         };
 
         // Dictionary to map camera makers to their normalized names with special cases    
         private static readonly Dictionary<string, string> SpecialFixes = new(StringComparer.OrdinalIgnoreCase)
         {
+            { "ASASHI OPTICAL", "Pentax" },
+            { "BENQ_E72", "BenQ" },
+            { "CASIO COMPUTER", "Casio" },
+            { "CONCORD CAMERA", "Concord" },
+            { "DAISY MULTIMEDIA", "Daisy Multimedia" },
+            { "DXG TECH", "DGX" },
+            { "EASTMAN KODAK", "Kodak" },
+            { "EASTMAN-KODAK", "Kodak" },
+            { "FLIR SYSTEMS", "FLIR" },
+            { "FUJI PHOTO", "Fujifilm" },
+            { "GATEWAY", "Gateway" },
+            { "HEWLETT PACKARD", "HP" },
             { "HEWLETT-PACKARD", "HP" },
+            { "JENIMAGE", "Jenimage" },
+            { "JK IMAGING", "JK Imaging" },
+            { "HITACHI LIVING SYSTEMS", "Hitachi" },
             { "KONICA MINOLTA", "Konica Minolta" },
-            { "KONICA MINOLTA CAMERA, Inc.", "Konica Minolta" },
-            { "LG ELECTRONICS", "LG" },
-            { "Minolta Co., Ltd.", "Minolta" },
-            { "NIKON CORPORATION", "Nikon" },
-            { "CASIO COMPUTER CO.,LTD", "Casio" },
-            { "EASTMAN KODAK COMPANY", "Kodak" },
-            { "OLYMPUS CORPORATION", "Olympus" },
-            { "OLYMPUS IMAGING CORP.", "Olympus" },
-            { "OLYMPUS OPTICAL CO.,LTD", "Olympus" },
-            { "SAMSUNG TECHWIN CO., LTD.", "Samsung" },
-            { "SAMSUNG ELECTRONICS", "Samsung" },
-            { "SAMSUNG TECHWIN", "Samsung" },
-            { "SONY CORPORATION", "Sony" },
-            { "SONY INTERACTIVE ENTERTAINMENT", "Sony" },
-            { "SONY MOBILE COMMUNICATIONS INC.", "Sony" },
-            { "SONY MOBILE COMMUNICATIONS", "Sony" },
-            { "SONY ERICSSON MOBILE COMMUNICATIONS AB", "Sony Ericsson" },
+            { "KONICA CORPORATION", "Konica" },
+            { "LEGEND", "Legend DSC" },
+            { "LEICA CAMERA", "Leica" },
+            { "LG ELEC", "LG" },
+            { "LG Mobile", "LG" },
+            { "LG_ELECTRONICS", "LG" },
+            { "LUMICRON TECHNOLOGY", "Lumicron" },
+            { "MADE BY POLAROID", "Polaroid" },
+            { "MAGINON", "Magion" },
+            { "MEDION OPTICAL", "MEDION" },
+            { "Mamiya-OP", "Mamiya" }, 
+            { "MOTOROLA KOREA", "Motorola" },
+            { "MOTOROLA MOBILITY", "Motorola" },
+            { "MINOLTA", "Minolta" },
+            { "OM Digital Solutions", "OM System" },
+            { "OLYMPUS IMAGING", "Olympus" },
+            { "OLYMPUS OPTICAL", "Olympus" },
+            { "PANTECH WIRELESS", "Pantech" },
+            { "PENTACON GERMANY", "Pentacon" },
             { "PENTAX CORPORATION", "Pentax" },
-            { " CORPORATION", "" },
-            { " TECHWIN CO.,LTD.", "" },
-            { " CO.,LTD.", "" },
-            { " ELECTRIC CO.,LTD.", "" },
-            { " ELECTRIC CO.,LTD", "" },
-            { " IMAGING CORP.", "" }
+            { "RESEARCH IN MOTION", "RIM" },
+            { "RICOH IMAGING", "Ricoh" },
+            { "RICOH IMAGING COMPANY", "Ricoh" },
+            { "SAMSUNG ELEC", "Samsung" },
+            { "SAMSUNG TECHWIN", "Samsung Techwin" },
+            { "SANYO ELECTRIC", "Sanyo" },
+            { "SEIKO EPSON", "Seiko Epson" },
+            { "SKANHEX", "Skanhex" },
+            { "SONY ERICSSON", "Sony Ericsson" },
+            { "SONY INTERACTIVE ENTERTAINMENT", "Sony" },
+            { "SONY MOBILE COMMUNICATIONS", "Sony" },
+            { "SONY-ERICSSON", "Sony Ericsson" },
+            { "SONYERICSSON", "Sony Ericsson" },
+            { "SUPRA", "Supra" },
+            { "TRAVELER OPTICAL", "Traveler Optical" },
+            { "YAKUMO", "Yakumo" }
         };
+
+
 
         private static readonly Dictionary<string, string> CameraModelMap = new(StringComparer.OrdinalIgnoreCase)
         {
-            { " DIGITAL", "" },
-            { " CAMERA", "" },
-            { " DIGITAL CAMERA", "" },
-            { " FILM SCANNER", "Film Scanner" },
-            { " SCANNER", "Scanner" },
-            { " PHOTO SCANNER", "Photo Scanner" },
-            { "POWERSHOT", "PowerShot" },
-            { "FINEPIX" , "FinePix"},
-            { "COOLPIX", "Coolpix" },
-            { "PHOTOSMART", "PhotoSmart" },
-            { "CYBERSHOT", "Cybershot" },
-            { "SCANJET", "ScanJet" },
-            { "OFFICEJET", "OfficeJet" },
-            { " DIMAGE", " DiMAGE" },
+            { "POWERSHOT", "PowerShot " },
+            { "FINEPIX" , "FinePix "},
+            { "REBEL", "Rebel " },
+            { "COOLPIX", "Coolpix " },
+            { "PERFECTION", "Perfection " },
+            { "CONCORD", "Concord " },
+            { "CANOSCAN", "CanoScan " },
+            { "PHOTOSMART", "PhotoSmart " },
+            { "CYBERSHOT", "Cybershot " },
+            { "SCANJET", "ScanJet " },
+            { "OFFICEJET", "OfficeJet " },
             { "DIMAGE ", "DiMAGE " },
-            { "PANORAMIC", "Panoramic" },
-            { "LUMIA", "Lumia" },
-            { "THETA", "Theta" },
-            { "STYLUS", "Stylus" },
+            { "PANORAMIC", "Panoramic " },
+            { "VIVICAM", "ViviCam " },
+            { "DROID", "Droid " },
+            { "LUMIA", "Lumia " },
+            { "THETA", "Theta " },
+            { "STYLUS", "Stylus " },
             { "MAGICSCAN", "MagicScan" },
-            { " ZOOM", "Zoom" }
+            { "EASYSHARE", "EasyShare" },
+            { "DIGITAL SCIENCE", "Digital Science" },
+            { "PLAYFULL", "Playfull" },
+            { "PLAYSPORT", "PlaySport" },
+            { "PIXPRO", "PixPro" },
+            { "COOLSCAN", "Coolscan" },
+            { "IZONE", "iZone" },
+            { "ALPHA SWEET DIGITAL", "Alpha Sweet Digital" },
+            { "SPEED STAR", "Speed Star" },
+            { "ALPHA", "Alpha" },
+            { "MAXXUM", "Maxxum" },
+            { "ASUS_", "Asus " },
+            { "EYE_Q", "Eye-Q " },
+            { "EYEQ", "Eye-Q " },
+            { " MEGAPIXEL", " Megapixel" }, 
+            { " SENSOR", " Sensor" },
+            { " ZOOM", " Zoom" },
+            { " FILM SCANNER", " Film Scanner" },
+            { " SCANNER", " Scanner" },
+            { " PHOTO SCANNER", " Photo Scanner" },
+            { " DIGITAL CAMERA", " Digital Camera" },
+            { " DIGITAL", " Digital" },
+            { " CAMERA", " Camera" },
+            { " DUAL LENS", " Dual Lens" },
+            { " CELLPHONE", " Cellphone" }
         };
 
 
+        /// <summary>
+        /// Normalize and compose a human-friendly device name from raw EXIF maker and model strings.
+        /// 
+        /// This method performs extensive cleaning and normalization:
+        /// - Makes inputs null-safe and trims whitespace; treats a single &quot;*&quot; model as empty.
+        /// - Strips angle brackets, question marks and common corporate suffixes (e.g., &quot;Inc.&quot;, &quot;Co., Ltd.&quot;) from the model.
+        /// - Applies pre-defined mapping dictionaries to normalize maker names (<see cref="CameraMakerMap"/> and <see cref="SpecialFixes"/>)
+        ///   and to normalize common model tokens and prefixes (<see cref="CameraModelMap"/>).
+        /// - Handles cases where the maker appears inside the model (removes duplicate maker mentions),
+        ///   and performs a set of final special-case string adjustments (e.g., &quot;HTC-&quot; &rarr; &quot;HTC &quot;).
+        /// 
+        /// The returned string is a single, human-readable device name (for example, &quot;Apple iPhone 11 Pro Max&quot; or
+        /// &quot;Canon PowerShot G7&quot;). If both inputs are empty or normalization yields no meaningful output, an empty string is returned.
+        /// </summary>
+        /// <param name="deviceMake">The raw maker string from metadata (may be null or empty).</param>
+        /// <param name="deviceModel">The raw model string from metadata (may be null or empty).</param>
+        /// <returns>
+        /// A normalized device name suitable for display or indexing. Returns an empty string if no maker or model information is available.
+        /// </returns>
         public static string GetDevice(string deviceMake, string deviceModel)
         {
-            string device   = String.Empty;
-            
-            deviceMake      = deviceMake.Trim();
-            deviceModel     = deviceModel.Trim();
+            // Make method null-safe
+            deviceMake ??= string.Empty;
+            deviceModel ??= string.Empty;
 
-            // Device make and model to uppercase for comparison
-            string upperMake = deviceMake.ToUpperInvariant();
-            string upperModel = deviceModel.ToUpperInvariant();
+            string device = String.Empty;
+
+            // Remove < > characters from device make and model
+            deviceMake = deviceMake.Replace("<", "").Replace(">", "");
+            deviceModel = deviceModel.Replace("<", "").Replace(">", "");
+
+            // Remove ? characters from device make and model
+            deviceMake = deviceMake.Replace("?", "");
+            deviceModel = deviceModel.Replace("?", "");
+
+            // Trim whitespace from device make and model
+            deviceMake = deviceMake.Trim();
+            deviceModel = deviceModel.Trim();
+
+            if (deviceModel == "*") { deviceModel = String.Empty; }
+
+            string[] removePatterns =
+            {
+                @"\s*TECHNOLOGY\s*CO\.?,?\s*LTD\.?",
+                @"\s*ELECTRIC\s*CO\.?,?\s*LTD\.?",
+                @"\s*IMAGING\s*CORP\.?",
+                @"\s*CAMERA\s*CORP\.?",
+                @"\s*CAMERA\s*GMBH",
+                @"\s*OPTICAL\s*CO\.?,?\s*LTD\.?",
+                @"\s*CORPORATION",
+                @"\s*COMPANY",
+                @"\s*INTERNATIONAL\s*INC\.?",
+                @"\s*GMBH",
+                @"\s*CORP.",
+                @"\s*INC.",
+                @"\s*CO\.?,?\s*LTD\.?",
+                @"\s*LTD.",
+                @"\s*CO.",
+                @"\(C\)",
+                @"\(R\)",
+                @"\.",
+                @",",
+                @"\*"
+            };
+
+            foreach (var pattern in removePatterns)
+            {
+                deviceModel = Regex.Replace(deviceModel, pattern, "", RegexOptions.IgnoreCase);
+            }
+            deviceModel = Regex.Replace(deviceModel, @"\s+", " ").Trim();
+
+            deviceModel = deviceModel.Trim();
+            
+            // If both device make and model are empty, return an empty string
+            if (string.IsNullOrWhiteSpace(deviceModel) && string.IsNullOrWhiteSpace(deviceMake))
+            {
+                return string.Empty;
+            }
 
             // Normalize the device make
-            if (string.IsNullOrWhiteSpace(deviceMake)==false)
+            if (!string.IsNullOrWhiteSpace(deviceMake))
             {
+                // Apply special fixes first
                 foreach (var fix in SpecialFixes)
                 {
-                    if (upperMake.Contains(fix.Key.ToUpperInvariant()) || deviceMake == fix.Key)
+                    if (deviceMake.ToUpperInvariant().Contains(fix.Key))
                     {
                         deviceMake = fix.Value;
                         break;
                     }
                 }
 
-                if (CameraMakerMap.TryGetValue(upperMake, out var normalizedMake))
+                // Apply general maker normalization
+                foreach (var maker in CameraMakerMap)
                 {
-                    deviceMake = normalizedMake;
-                }
-
-                if (CameraModelMap.TryGetValue(upperMake, out var normalizedModelText))
-                {
-                    deviceMake = normalizedModelText;
+                    if (deviceMake.ToUpperInvariant().Contains(maker.Key))
+                    {
+                        deviceMake = maker.Value;
+                        break;
+                    }
                 }
             }
 
             // If device model is empty, return the device make or an empty string, else normalize the model
             if (string.IsNullOrWhiteSpace(deviceModel))
             {
-                return deviceMake ?? String.Empty;
+                 return deviceMake ?? String.Empty;
             }
             else
             {
@@ -203,50 +498,52 @@ namespace ImageDB
                 foreach (var maker in CameraMakerMap)
                 {
                     // Check if the input string contains the maker followed by a hyphen
-                    if (upperModel.Contains(maker.Key + "-"))
+                    if (deviceModel.ToUpperInvariant().Contains(maker.Key + "-"))
                     {
                         // Replace the dash with a space after the maker
-                        deviceModel = deviceModel.Replace(maker.Key + "-", maker.Value + " ");
-                        break; // Exit loop after the first replacement
-                    }
-                }
-
-                foreach (var maker in CameraMakerMap)
-                {
-                    // Check if the input string contains the maker followed by a hyphen
-                    if (upperModel.Contains(maker.Key))
-                    {
-                        // Replace the dash with a space after the maker
-                        deviceModel = deviceModel.Replace(maker.Key, maker.Value);
+                        deviceModel = Regex.Replace(deviceModel, Regex.Escape(maker.Key + "-"), maker.Value + " ", RegexOptions.IgnoreCase);
                         break; // Exit loop after the first replacement
                     }
                 }
 
                 foreach (var model in CameraModelMap)
                 {
-                    // Check if the input string contains the maker followed by a hyphen
-                    if (upperModel.Contains(model.Key))
+                    // Check if the model string contains the model key
+                    if (deviceModel.ToUpperInvariant().Contains(model.Key))
                     {
-                        // Replace the dash with a space after the maker
-                        deviceModel = deviceModel.Replace(model.Key, model.Value);
+                        // Replace the model value with the normalized model name
+                        deviceModel = Regex.Replace(deviceModel, Regex.Escape(model.Key), model.Value, RegexOptions.IgnoreCase);
                     }
                 }
+
+                // Remove extra spaces in device model
+                deviceModel = deviceModel.Replace("  ", " ");
 
             }
 
             // If device make is empty, return the device model
             deviceMake ??= String.Empty;
 
-            // If device make is not empty and device model contains device make, remove device make from device model
+            // If device make is not empty and device model contains device make, remove device make.
             if (!string.IsNullOrEmpty(deviceMake) &&
                 deviceModel.ToUpperInvariant().Contains(deviceMake.ToUpperInvariant()))
             {
+                deviceModel = Regex.Replace(deviceModel, Regex.Escape(deviceMake), deviceMake, RegexOptions.IgnoreCase);
                 deviceMake = String.Empty;
             }
 
             device = deviceMake + " " + deviceModel;
             device = device.Trim();
             device = device.Replace("  ", " ");
+
+            // Final special cases
+            device = device.Replace("Kodak Kodak", "Kodak");
+            device = device.Replace("Hewlett Packard HP", "HP");
+            if (device == "Digimax101") { device = "Samsung Digimax 101"; }
+            if (device.StartsWith("HTC-")) { device = device.Replace("HTC-", "HTC "); }
+            if (device.StartsWith("HTC_")) { device = device.Replace("HTC_", "HTC "); }
+            if (device.StartsWith("ZTE-")) { device = device.Replace("ZTE-", "ZTE "); }
+            if (device.StartsWith("hp ")) { device = device.Replace("hp ", "HP "); }
 
             return device;
         }

--- a/console/ImageFile.cs
+++ b/console/ImageFile.cs
@@ -5,15 +5,62 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace ImageDB
-{    public class ImageFile
+{
+    /// <summary>
+    /// Represents metadata about a single image file in the ImageDB application.
+    /// </summary>
+    /// <remarks>
+    /// This class stores common file-level metadata used by the application, including
+    /// the file path, file name, extension, human-readable file size, and creation/modification timestamps.
+    /// - <see cref="FilePath"/>: full path to the file on disk.
+    /// - <see cref="FileName"/>: file name including.
+    /// - <see cref="FileExtension"/>: file extension.
+    /// - <see cref="FileSize"/>: file size in bytes.
+    /// - <see cref="FileCreatedDate"/> and <see cref="FileModifiedDate"/>: timestamp strings (ISO 8601 recommended).
+    /// Use this object for presenting file metadata in UIs, persisting simple indexes, or transferring lightweight file info
+    /// between application layers. For binary access or advanced metadata (EXIF), use specialized types or services.
+    /// </remarks>
+    public class ImageFile
     {
+        /// <summary>
+        /// Gets or sets the full path to the image file on disk.
+        /// </summary>
         public string FilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file modification date as a string. (yyyy-MM-dd hh:mm:ss tt).
+        /// </summary>
         public string FileModifiedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file extension.
+        /// </summary>
         public string FileExtension { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file name. Typically includes the extension.
+        /// </summary>
         public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file size in bytes.
+        /// </summary>
         public string FileSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file creation date as a string. (yyyy-MM-dd hh:mm:ss tt).
+        /// </summary>
         public string FileCreatedDate { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageFile"/> class with the provided metadata values.
+        /// </summary>
+        /// <param name="filePath">Full path to the file.</param>
+        /// <param name="fileModifiedDate">Modification timestamp as a string (yyyy-MM-dd hh:mm:ss tt).</param>
+        /// <param name="fileExtension">File extension, including the dot (e.g., ".png").</param>
+        /// <param name="fileName">File name.</param>
+        /// <param name="fileSize">File size in bytes.</param>
+        /// <param name="fileCreatedDate">Creation timestamp as a string (yyyy-MM-dd hh:mm:ss tt).</param>
         public ImageFile(string filePath, string fileModifiedDate, string fileExtension, string fileName, string fileSize, string fileCreatedDate)
         {
             FilePath = filePath;

--- a/console/LocationIdService.cs
+++ b/console/LocationIdService.cs
@@ -7,6 +7,10 @@ using System.Threading.Tasks;
 
 namespace ImageDB
 {
+    /// <summary>
+    /// LocationIdService: normalizes and persists location identifiers and names,
+    /// ensuring unique Location records and managing RelationLocation links to Image records.
+    /// </summary>
     public class LocationIdService
     {
         private readonly CDatabaseImageDBsqliteContext dbFiles;

--- a/console/MetadataStuct.cs
+++ b/console/MetadataStuct.cs
@@ -6,6 +6,16 @@ using System.Threading.Tasks;
 
 namespace ImageDB
 {
+
+    /// <summary>
+    /// Represents the collection of Metadata Working Group (MWG) types used by the ImageDB project.
+    /// This container class groups nested types that describe applied dimensions,
+    /// rectangular areas, region information and lists, and collection metadata.
+    /// These types are intended for serialization and data transfer of image
+    /// metadata such as region coordinates, units, names, and collection URIs.
+    /// Ref: https://web.archive.org/web/20120131102845/http://www.metadataworkinggroup.org/pdf/mwg_guidance.pdf
+    /// </summary>
+    /// 
     internal class MetadataStuct
     {
 

--- a/console/PeopleTagService.cs
+++ b/console/PeopleTagService.cs
@@ -7,6 +7,19 @@ using System.Threading.Tasks;
 
 namespace ImageDB
 {
+    /// <summary>
+    /// Service for managing people tags related to images.
+    /// 
+    /// What it does:
+    /// - Ensures a person's tag exists in the `PeopleTags` table (creates it if missing).
+    /// - Creates relation entries in `RelationPeopleTags` to associate a `PeopleTag` with an image.
+    /// - Removes all `RelationPeopleTag` entries for a given image.
+    /// 
+    /// This service operates against the provided `CDatabaseImageDBsqliteContext` and uses
+    /// Entity Framework Core to persist changes. Methods are intended to be used from
+    /// asynchronous workflows; callers should handle exceptions and concurrency as needed.
+    /// </summary>
+    
     public class PeopleTagService
     {
         private readonly CDatabaseImageDBsqliteContext dbFiles;

--- a/console/Sample_DeviceList.csv
+++ b/console/Sample_DeviceList.csv
@@ -1,0 +1,6984 @@
+,3MDSC
+,4M DSC
+,4MDSC
+,5.0M DigitalCAM
+,5M DSC
+,6M DSC
+,735S POWE
+AIPTEK,DV 5000
+AIPTEK,DV 5700
+AIPTEK,DV 6800
+AIPTEK,DV 6800S
+AIPTEK,DV 8800
+AIPTEK,DV 8800N
+AIPTEK,DV Cam2
+Aiptek International Inc.,DV M2
+Aiptek International Inc.,DZO-V59
+AIPTEK,HDDV 8300
+AIPTEK,VS-3
+Aiptek International Inc.,iDV
+Acer Inc.,C01
+ACER,CE-5330
+Acer,CE6430
+acer,CI-8330
+Acer Corporation,CI6330
+Acer,CL-6300
+acer,CP-8531
+Acer,CP-8660
+acer,CR8530
+acer,CS-6531
+ACER,CS5531
+acer,CS6530
+acer,CU-6530
+ACER,DX650
+ACER,ACER E101
+Acer,Acer Liquid
+Acer,Liquid Metal
+Acer,M900
+ACER,ACER S200
+Acer,Acer Stream
+ACER,X960
+AGFA,ARCUS II
+AGFAPHOTO,DC-1033m
+AGFAPHOTO,DC-2030m
+AGFAPHOTO,DC-302
+AGFAPHOTO,DC-500
+AgfaPhoto,DC-600uw
+AGFAPHOTO,DC-733s
+AGFAPHOTO,DC-833m
+AgfaPhoto,OPTIMA 100
+AgfaPhoto,OPTIMA 102
+AgfaPhoto,OPTIMA 103
+AgfaPhoto,OPTIMA 104
+AgfaPhoto,OPTIMA 105
+AGFAPHOTO,OPTIMA 1338mT
+AgfaPhoto,OPTIMA 1438m
+AGFAPHOTO,OPTIMA 2338mT
+AGFAPHOTO,OPTIMA 8328m
+Agfa Gevaert,SR841
+Agfa,SnapScan e25
+Agfa,ePhoto CL30
+AgfaPhoto,Compact 100
+AgfaPhoto,Compact 102
+AgfaPhoto,sensor 505-D
+Allied Vision Technologies,GT3300C (02-2623A)
+Allied Vision Technologies,GT3300C (02-2623B)
+Allied Vision Technologies,GT4907C (02-2637B)
+Amazon,Fire HD
+Amazon,Fire HD7
+Apple,QT-200
+Apple,iPad
+Apple,iPad (5th generation)
+Apple,iPad (6th generation)
+Apple,iPad 2
+Apple,iPad Air
+Apple,iPad Air (3rd generation)
+Apple,iPad Air (4th generation)
+Apple,iPad Air (5th generation)
+Apple,iPad Air 2
+Apple,iPad Pro
+Apple,iPad Pro (12.9-inch) (3rd generation)
+Apple,iPad Pro (12.9-inch) (4th generation)
+Apple,iPad Pro (12.9-inch) (5th generation)
+Apple,iPad Pro 10.5
+Apple,iPad mini
+Apple,iPad mini (5th generation)
+Apple,iPad mini 2
+Apple,iPad mini 3
+Apple,iPad mini 4
+Apple,iPhone
+Apple,iPhone 11
+Apple,iPhone 11 Pro
+Apple,iPhone 11 Pro Max
+Apple,iPhone 12 Pro
+Apple,iPhone 12 Pro Max
+Apple,iPhone 13
+Apple,iPhone 13 Pro
+Apple,iPhone 13 Pro Max
+Apple,iPhone 14
+Apple,iPhone 14 Pro
+Apple,iPhone 15
+Apple,iPhone 15 Plus
+Apple,iPhone 15 Pro
+Apple,iPhone 15 Pro Max
+Apple,iPhone 16 Pro
+Apple,iPhone 3G
+Apple,iPhone 3GS
+Apple,iPhone 4
+Apple,iPhone 4S
+Apple,iPhone 5
+Apple,iPhone 5S
+Apple,iPhone 5c
+Apple,iPhone 5s
+Apple,iPhone 6
+Apple,iPhone 6 Plus
+Apple,iPhone 6s
+Apple,iPhone 6s Plus
+Apple,iPhone 7
+Apple,iPhone 7 Plus
+Apple,iPhone 8
+Apple,iPhone 8 Plus
+Apple,iPhone SE
+Apple,iPhone SE (1st generation)
+Apple,iPhone SE (2nd generation)
+Apple,iPhone X
+Apple,iPhone XR
+Apple,iPhone XS
+Apple,iPhone XS Max
+Apple,"iPhone6,1 - 7.1.2"
+Apple,"iPhone6,1 - 8.0"
+Apple,"iPhone6,1 - 8.0.2"
+Apple,"iPhone6,1 - 8.1.2"
+Apple,"iPhone6,1 - 8.3"
+Apple,"iPhone6,1 - 9.0.2"
+Apple,iPod touch
+Arashi Vision,Insta360 EVO
+"Asahi Optical Co., Ltd.",PENTAX EI-100
+"Asahi Optical Co.,Ltd",PENTAX DB100
+"Asahi Optical Co.,Ltd",PENTAX Optio 330
+"Asahi Optical Co.,Ltd",PENTAX Optio 430
+"Asahi Optical Co.,Ltd.",PENTAX Optio 230
+"Asahi Optical Co.,Ltd.",PENTAX Optio330RS
+"Asahi Optical Co.,Ltd.",PENTAX Optio430RS
+asus,ASUS_Z01KDA
+BBK Imaging Co.,DP1050
+BBK Imaging Co.,DP1250
+BBK Imaging Co.,DP710
+BBK Imaging Co.,DP810
+BBK Imaging Co.,DP830
+BENQ,3310
+BenQ,C1050
+BenQ,C640
+BenQ,C740i
+BenQ,C745
+BENQ,DC 2110
+BenQ,DC C1000
+BenQ Corporation,DC C1020
+BenQ Corporation,DC C1060
+BenQ Corporation,DC C1220
+BenQ Corporation,DC C1230
+BenQ,DC C420
+BenQ,DC C50
+BenQ,DC C500
+BenQ,DC C510
+BenQ,DC C520
+BenQ,DC C530
+BenQ,DC C540
+BenQ,DC C60
+BenQ,DC C610
+BenQ,DC C630
+BenQ,DC C700
+BenQ,DC C740
+BenQ,DC C750
+BenQ,DC C800
+BenQ,DC C840
+BenQ,DC C850
+BenQ,DC E1000
+BenQ,DC E1020
+BenQ Corporation,DC E1050
+BenQ Corporation,DC E1050t
+BenQ Corporation,DC E1220
+BenQ Corporation,DC E1230
+BenQ Corporation,DC E1260
+BenQ,DC E30
+BenQ,DC E300
+BenQ,DC E310
+BenQ,DC E43
+BenQ,DC E520+
+BenQ,DC E53
+BenQ,DC E600
+BenQ,DC E605
+BenQ,DC E610
+BenQ,DC E63+
+BenQ,DC E720
+BenQ,DC E800
+BenQ,DC E820
+BenQ,DC P500
+BenQ,DC P860
+BenQ Corporation,DC T1260
+BenQ Corporation,BenQ DC T700
+BenQ Corporation,BenQ DC T800
+BenQ Corporation,DC T850
+BenQ,DC X600
+BenQ,DC X720
+BenQ Corporation,BenQ DC X725
+BenQ Corporation,BenQ DC X735
+BenQ Corporation,BenQ DC X800
+BenQ Corporation,BenQ DC X835
+BenQ,DC1500
+BENQ,BENQ DC2300
+BENQ,BENQ DC2310
+BENQ,BENQ DC2410
+BenQ Corporation,DV M1
+BenQ,E53+
+BenQ-Siemens,E81
+BenQ-Siemens,EF 81
+BenQ,G1
+BenQ Corporation,GH20X
+BenQ Corporation,GH700
+BenQ Corporation,LM100
+BenQ-Siemens,S81
+BenQ-Siemens,S88
+BenQ,UlyC2A 1.291
+BenQ_E72,BenQ_E72
+BlackBerry,BBB100-2
+blackberry,PRIV
+BlackBerry,BlackBerry Passport
+BlackBerry,BlackBerry Q10
+blackberry,STH100-2
+BlackBerry,Unknown
+BUSHNELL,
+BUSHNELL,87C
+,Cam 3200
+,Camera
+CAMERA,CAMERA
+CAMERA,10MP-9KA
+CAMERA,10MP-9KB
+CAMERA,2MP-9D1
+CAMERA,3MP-9CA
+CAMERA,3MP-9F6
+Camera,3MP-9N2
+Camera,3MP-9P2
+CAMERA,3MP-9P5
+CAMERA,4MP-859
+CAMERA,4MP-9J6
+CAMERA,4MP-9J9
+CAMERA,4MP-9Q3
+CAMERA,4MP-9T2
+CAMERA,5MP-9A3
+CAMERA,5MP-9EY
+CAMERA,5MP-9G4
+Digital Camera,5MP-9J2
+CAMERA,5MP-9M2
+CAMERA,5MP-9M7
+CAMERA,5MP-9P8
+CAMERA,5MP-9Q2
+CAMERA,5MP-9Q3
+CAMERA,5MP-9T3
+CAMERA,5MP-9W5
+CAMERA,5MP-9X9
+CAMERA,5MP-9Y2
+CAMERA,5MP-9Y9
+CAMERA,6MP-9FA
+CAMERA,6MP-9FH
+CAMERA,6MP-9J5
+CAMERA,6MP-9N3
+CAMERA,6MP-9T6
+CAMERA,6MP-9U7
+CAMERA,6MP-9U9
+Digital Camera,6MP-9Y8
+CAMERA,6MP9Q3
+CAMERA,6MP9U2
+CAMERA,6MP9W4
+CAMERA,7MP-9GA
+CAMERA,7MP-9GB
+CAMERA,7MP-9GH
+CAMERA,7MP-9GL
+CAMERA,7MP-9GM
+Camera,8MP-9HC
+CAMERA,8MP-9HG
+        Camera,8MP-9HX
+CAMERA,8MP-9Q6
+Digital Camera,8MP-9T9
+CAMERA,8MP-9U4
+CAMERA,8MP-9V9
+CAMERA,CE5430
+Digital Camera,CL-5300
+Digital Camera,DB 3MP
+ CAMERA,DC-3305
+Camera,DC-4300
+Camera,DC-4330
+7M 3X Digital Camera,DC-733i
+CAMERA,DC1310
+CAMERA,DC2070
+CAMERA,DC2071
+CAMERA,DC2300
+CAMERA,DC2302
+CAMERA,DC3301
+ CAMERA,DC3306
+CAMERA,DC3A30
+Digital Camera,DC5085
+Digital Camera,DS5MP
+Jenoptik Camera GmbH,Jenoptik JD C5.0SL
+5.0M Digital Camera,MP5
+ Campark,  ACT74
+Canon,CanoScan 4400F
+Canon,CanoScan 5200F
+Canon,CanoScan 5600F
+Canon,CanoScan 8400F
+Canon,CanoScan 8600F
+Canon,CanoScan 8800F
+Canon,CanoScan 9950F
+Canon Inc.,CanoScan FB630U/FB636U
+Canon,CanoScan LiDE 100
+Canon,CanoScan LiDE 200
+Canon,CanoScan LiDE 25
+Canon,CanoScan LiDE 500F
+Canon,CanoScan LiDE 60
+Canon,CanoScan LiDE 600F
+Canon,CanoScan LiDE 70
+Canon,CanoScan LiDE 700F
+Canon,CanoScan LiDE 90
+Canon Inc.,CanoScan N650U/N656U
+Canon,Canon DC10
+Canon,Canon DC100
+Canon,Canon DC19
+Canon,Canon DC20
+Canon,Canon DC201
+Canon,Canon DC21
+Canon,Canon DC210
+Canon,Canon DC211
+Canon,Canon DC22
+Canon,Canon DC220
+Canon,Canon DC230
+Canon,Canon DC301
+Canon,Canon DC310
+Canon,Canon DC311
+Canon,Canon DC320
+Canon,Canon DC330
+Canon,Canon DC40
+Canon,Canon DC410
+Canon,Canon DC411
+Canon,Canon DC420
+Canon,Canon DC50
+Canon,DM-GL2
+Canon,DM-XM2
+Canon,Canon DV 001
+Canon,Canon DV 011
+Canon,Canon DV 012
+Canon,Canon DV 013
+Canon,Canon DV 021
+Canon,Canon DIGITAL IXUS
+Canon,Canon DIGITAL IXUS 100 IS
+Canon,Canon DIGITAL IXUS 110 IS
+Canon,Canon DIGITAL IXUS 120 IS
+Canon,Canon DIGITAL IXUS 200 IS
+Canon,Canon DIGITAL IXUS 30
+Canon,Canon DIGITAL IXUS 300
+Canon,Canon DIGITAL IXUS 330
+Canon,Canon DIGITAL IXUS 40
+Canon,Canon DIGITAL IXUS 400
+Canon,Canon DIGITAL IXUS 430
+Canon,Canon DIGITAL IXUS 50
+Canon,Canon DIGITAL IXUS 500
+Canon,Canon DIGITAL IXUS 55
+Canon,Canon DIGITAL IXUS 60
+Canon,Canon DIGITAL IXUS 65
+Canon,Canon DIGITAL IXUS 70
+Canon,Canon DIGITAL IXUS 700
+Canon,Canon DIGITAL IXUS 75
+Canon,Canon DIGITAL IXUS 750
+Canon,Canon DIGITAL IXUS 80 IS
+Canon,Canon DIGITAL IXUS 800 IS
+Canon,Canon DIGITAL IXUS 82 IS
+Canon,Canon DIGITAL IXUS 85 IS
+Canon,Canon DIGITAL IXUS 850 IS
+Canon,Canon DIGITAL IXUS 860 IS
+Canon,Canon DIGITAL IXUS 870 IS
+Canon,Canon DIGITAL IXUS 90 IS
+Canon,Canon DIGITAL IXUS 900 Ti
+Canon,Canon DIGITAL IXUS 95 IS
+Canon,Canon DIGITAL IXUS 950 IS
+Canon,Canon DIGITAL IXUS 960 IS
+Canon,Canon DIGITAL IXUS 970 IS
+Canon,Canon DIGITAL IXUS 980 IS
+Canon,Canon DIGITAL IXUS 990 IS
+Canon,Canon DIGITAL IXUS II
+Canon,Canon DIGITAL IXUS IIs
+Canon,Canon DIGITAL IXUS WIRELESS
+Canon,Canon DIGITAL IXUS i
+Canon,Canon DIGITAL IXUS i zoom
+Canon,Canon DIGITAL IXUS i5
+Canon,Canon DIGITAL IXUS i7 zoom
+Canon,Canon DIGITAL IXUS v
+Canon,Canon DIGITAL IXUS v2
+Canon,Canon DIGITAL IXUS v3
+Canon,Canon ELURA100
+Canon,Canon ELURA40 MC
+Canon,Canon ELURA50
+Canon,Canon ELURA60
+Canon,Canon ELURA65
+Canon,Canon ELURA70
+Canon,Canon ELURA80
+Canon,Canon ELURA85
+Canon,Canon ELURA90
+Canon,Canon EOS 1000D
+Canon,Canon EOS 100D
+Canon,Canon EOS 10D
+Canon,Canon EOS 1100D
+Canon,Canon EOS 1200D
+Canon,Canon EOS 1300D
+Canon,Canon EOS 2000D
+Canon,Canon EOS 200D
+Canon,Canon EOS 20D
+Canon,Canon EOS 250D
+Canon,Canon EOS 300D DIGITAL
+Canon,Canon EOS 30D
+Canon,Canon EOS 350D DIGITAL
+Canon,Canon EOS 4000D
+Canon,Canon EOS 400D DIGITAL
+Canon,Canon EOS 40D
+Canon,Canon EOS 450D
+Canon,Canon EOS 500D
+Canon,Canon EOS 50D
+Canon,Canon EOS 550D
+Canon,Canon EOS 5D
+Canon,Canon EOS 5D Mark II
+Canon,Canon EOS 5D Mark III
+Canon,Canon EOS 5D Mark IV
+Canon,Canon EOS 5DS
+Canon,Canon EOS 5DS R
+Canon,Canon EOS 600D
+Canon,Canon EOS 60D
+Canon,Canon EOS 650D
+Canon,Canon EOS 6D
+Canon,Canon EOS 6D Mark II
+Canon,Canon EOS 700D
+Canon,Canon EOS 70D
+Canon,Canon EOS 750D
+Canon,Canon EOS 760D
+Canon,Canon EOS 77D
+Canon,Canon EOS 7D
+Canon,Canon EOS 7D Mark II
+Canon,Canon EOS 8000D
+Canon,Canon EOS 800D
+Canon,Canon EOS 80D
+Canon,Canon EOS 850D
+Canon,Canon EOS 9000D
+Canon,Canon EOS 90D
+Canon,Canon EOS C300
+Canon,Canon EOS D30
+Canon,Canon EOS D60
+Canon,Canon EOS DIGITAL REBEL
+Canon,Canon EOS DIGITAL REBEL XS
+Canon,Canon EOS DIGITAL REBEL XSi
+Canon,Canon EOS DIGITAL REBEL XT
+Canon,Canon EOS DIGITAL REBEL XTi
+Canon,Canon EOS K236
+Canon,Canon EOS Kiss Digital
+Canon,Canon EOS Kiss Digital N
+Canon,Canon EOS Kiss Digital X
+Canon,Canon EOS Kiss F
+Canon,Canon EOS Kiss X10
+Canon,Canon EOS Kiss X2
+Canon,Canon EOS Kiss X3
+Canon,Canon EOS Kiss X4
+Canon,Canon EOS Kiss X5
+Canon,Canon EOS Kiss X50
+Canon,Canon EOS Kiss X6i
+Canon,Canon EOS Kiss X7
+Canon,Canon EOS Kiss X70
+Canon,Canon EOS Kiss X7i
+Canon,Canon EOS Kiss X8i
+Canon,Canon EOS Kiss X9
+Canon,Canon EOS Kiss X90
+Canon,Canon EOS Kiss X9i
+Canon,Canon EOS M
+Canon,Canon EOS M10
+Canon,Canon EOS M100
+Canon,Canon EOS M2
+Canon,Canon EOS M200
+Canon,Canon EOS M3
+Canon,Canon EOS M5
+Canon,Canon EOS M50
+Canon,Canon EOS M6
+Canon,Canon EOS M6 Mark II
+Canon,Canon EOS R
+Canon,Canon EOS R1
+Canon,Canon EOS R10
+Canon,Canon EOS R100
+Canon,Canon EOS R5
+Canon,Canon EOS R50
+Canon,Canon EOS R50 V
+Canon,Canon EOS R5m2
+Canon,Canon EOS R6
+Canon,Canon EOS R6m2
+Canon,Canon EOS R7
+Canon,Canon EOS R8
+Canon,Canon EOS REBEL T1i
+Canon,Canon EOS REBEL T2i
+Canon,Canon EOS REBEL T3i
+Canon,Canon EOS DIGITAL REBEL XSi
+Canon,Canon EOS DIGITAL REBEL XT
+Canon,Canon EOS DIGITAL REBEL XTi
+Canon,Canon EOS RP
+Canon,Canon EOS REBEL SL1
+Canon,Canon EOS Rebel SL2
+Canon,Canon EOS Rebel SL3
+Canon,Canon EOS REBEL T1i
+Canon,Canon EOS REBEL T2i
+Canon,Canon EOS REBEL T3
+Canon,Canon EOS REBEL T3i
+Canon,Canon EOS REBEL T4i
+Canon,Canon EOS REBEL T5
+Canon,Canon EOS REBEL T5i
+Canon,Canon EOS Rebel T6
+Canon,Canon EOS Rebel T6i
+Canon,Canon EOS Rebel T6s
+Canon,Canon EOS Rebel T7
+Canon,Canon EOS Rebel T7i
+Canon,Canon EOS Rebel T8i
+Canon,Canon EOS-1D
+Canon,Canon EOS-1D C
+Canon,Canon EOS-1D Mark II
+Canon,Canon EOS-1D Mark II N
+Canon,Canon EOS-1D Mark III
+Canon,Canon EOS-1D Mark IV
+Canon,Canon EOS-1D X
+Canon,Canon EOS-1D X Mark II
+Canon,Canon EOS-1D X Mark III
+Canon,Canon EOS-1DS
+Canon,Canon EOS-1Ds Mark II
+Canon,Canon EOS-1Ds Mark III
+Canon,Canon FS10
+Canon,Canon FS100
+Canon,Canon FS11
+Canon,Canon FS300
+Canon,Canon FS31
+Canon,Canon FV M1
+Canon,Canon FV M10
+Canon,Canon FV M100
+Canon,Canon FV M20
+Canon,Canon FV M200
+Canon,Canon FV M30
+Canon,Canon FV40
+Canon,Canon HF10
+Canon,Canon HF100
+Canon,Canon HF11
+Canon,Canon HG10
+Canon,Canon HG20
+Canon,Canon HG21
+Canon,Canon HR10
+Canon,Canon HV10
+Canon,Canon HV20
+Canon,Canon HV30
+Canon,Canon IXUS 1000HS
+Canon,Canon IXUS 105
+Canon,Canon IXUS 1100 HS
+Canon,Canon IXUS 115 HS
+Canon,Canon IXUS 125 HS
+Canon,Canon IXUS 130
+Canon,Canon IXUS 132
+Canon,Canon IXUS 135
+Canon,Canon IXUS 140
+Canon,Canon IXUS 145
+Canon,Canon IXUS 150
+Canon,Canon IXUS 155
+Canon,Canon IXUS 160
+Canon,Canon IXUS 165
+Canon,Canon IXUS 170
+Canon,Canon IXUS 175
+Canon,Canon IXUS 185
+Canon,Canon IXUS 210
+Canon,Canon IXUS 220 HS
+Canon,Canon IXUS 230 HS
+Canon,Canon IXUS 240 HS
+Canon,Canon IXUS 245 HS
+Canon,Canon IXUS 255 HS
+Canon,Canon IXUS 265 HS
+Canon,Canon IXUS 275 HS
+Canon,Canon IXUS 300 HS
+Canon,Canon IXUS 310 HS
+Canon,Canon IXUS 500 HS
+Canon,Canon IXUS 510 HS
+Canon,Canon IXY 1
+Canon,Canon IXY 100F
+Canon,Canon IXY 10S
+Canon,Canon IXY 110F
+Canon,Canon IXY 120
+Canon,Canon IXY 130
+Canon,Canon IXY 140
+Canon,Canon IXY 180
+Canon,Canon IXY 190
+Canon,Canon IXY 200F
+Canon,Canon IXY 210F
+Canon,Canon IXY 220F
+Canon,Canon IXY 3
+Canon,Canon IXY 30S
+Canon,Canon IXY 31S
+Canon,Canon IXY 32S
+Canon,Canon IXY 400F
+Canon,Canon IXY 410F
+Canon,Canon IXY 420F
+Canon,Canon IXY 430F
+Canon,Canon IXY 50S
+Canon,Canon IXY 51S
+Canon,Canon IXY 600F
+Canon,Canon IXY 610F
+Canon,Canon IXY 620F
+Canon,Canon IXY 630
+Canon,Canon IXY 640
+Canon,Canon IXY 650
+Canon,Canon IXY 90F
+Canon,Canon IXY DV 3
+Canon,Canon IXY DV 5
+Canon,Canon IXY DV M
+Canon,Canon IXY DV M2
+Canon,Canon IXY DV M3
+Canon,Canon IXY DV M5
+Canon,Canon IXY DIGITAL
+Canon,Canon IXY DIGITAL 10
+Canon,Canon IXY DIGITAL 1000
+Canon,Canon IXY DIGITAL 110 IS
+Canon,Canon IXY DIGITAL 20 IS
+Canon,Canon IXY DIGITAL 200
+Canon,Canon IXY DIGITAL 2000 IS
+Canon,Canon IXY DIGITAL 200a
+Canon,Canon IXY DIGITAL 210 IS
+Canon,Canon IXY DIGITAL 220 IS
+Canon,Canon IXY DIGITAL 25 IS
+Canon,Canon IXY DIGITAL 30
+Canon,Canon IXY DIGITAL 300
+Canon,Canon IXY DIGITAL 3000 IS
+Canon,Canon IXY DIGITAL 300a
+Canon,Canon IXY DIGITAL 30a
+Canon,Canon IXY DIGITAL 320
+Canon,Canon IXY DIGITAL 40
+Canon,Canon IXY DIGITAL 400
+Canon,Canon IXY DIGITAL 450
+Canon,Canon IXY DIGITAL 50
+Canon,Canon IXY DIGITAL 500
+Canon,Canon IXY DIGITAL 510 IS
+Canon,Canon IXY DIGITAL 55
+Canon,Canon IXY DIGITAL 60
+Canon,Canon IXY DIGITAL 600
+Canon,Canon IXY DIGITAL 70
+Canon,Canon IXY DIGITAL 700
+Canon,Canon IXY DIGITAL 80
+Canon,Canon IXY DIGITAL 800 IS
+Canon,Canon IXY DIGITAL 810 IS
+Canon,Canon IXY DIGITAL 820 IS
+Canon,Canon IXY DIGITAL 830 IS
+Canon,Canon IXY DIGITAL 90
+Canon,Canon IXY DIGITAL 900 IS
+Canon,Canon IXY DIGITAL 910 IS
+Canon,Canon IXY DIGITAL 920 IS
+Canon,Canon IXY DIGITAL 930 IS
+Canon,Canon IXY DIGITAL 95 IS
+Canon,Canon IXY DIGITAL L
+Canon,Canon IXY DIGITAL L2
+Canon,Canon IXY DIGITAL L3
+Canon,Canon IXY DIGITAL L4
+Canon,Canon IXY DIGITAL WIRELESS
+Canon,Canon LEGRIA FS19
+Canon,Canon LEGRIA FS20
+Canon,Canon LEGRIA FS200
+Canon,Canon LEGRIA FS21
+Canon,Canon LEGRIA FS22
+Canon,Canon LEGRIA FS305
+Canon,Canon LEGRIA FS306
+Canon,Canon LEGRIA FS307
+Canon,Canon LEGRIA FS36
+Canon,Canon LEGRIA FS37
+Canon,Canon LEGRIA HF G25
+Canon,Canon LEGRIA HF M306
+Canon,Canon LEGRIA HF M31
+Canon,Canon LEGRIA HF M36
+Canon,Canon LEGRIA HF R106
+Canon,Canon LEGRIA HF R16
+Canon,Canon LEGRIA HF R17
+Canon,Canon LEGRIA HF R18
+Canon,Canon LEGRIA HF S10
+Canon,Canon LEGRIA HF S100
+Canon,Canon LEGRIA HF S11
+Canon,Canon LEGRIA HF S20
+Canon,Canon LEGRIA HF S200
+Canon,Canon LEGRIA HF S21
+Canon,Canon LEGRIA HF20
+Canon,Canon LEGRIA HF200
+Canon,Canon LEGRIA HF21
+Canon,Canon LEGRIA HV40
+Canon,LiDE 20
+Canon,LiDE 30
+Canon,LiDE 35
+Canon,LiDE 80
+Canon,Canon MD130
+Canon,Canon MD140
+Canon,Canon MD150
+Canon,Canon MD160
+Canon,Canon MD255
+Canon,Canon MF3110
+Canon,Canon MF3200 Series
+Canon,Canon MF4010 Series
+Canon,Canon MF4100 Series
+Canon,Canon MF4200 Series
+Canon,Canon MF4600 Series
+Canon,Canon MF5770
+Canon,Canon MF6500 Series
+Canon Inc.,Canon MP150
+Canon,MP210 series
+Canon,MP220
+Canon,MP220 series
+Canon,MP240 series
+Canon,MP480 series
+Canon,MP520 series
+Canon Inc.,Canon MP530
+Canon,MP540 series
+Canon,Canon MP610 series
+Canon,MP980 series
+Canon,Canon MV5i MC
+Canon,Canon MV630i
+Canon,Canon MV650i
+Canon,Canon MV6i MC
+Canon,Canon MV730i
+Canon,Canon MV750i
+Canon,Canon MV830(i)
+Canon,Canon MV850i
+Canon,Canon MV880X(i)
+Canon,Canon MV930
+Canon,Canon MV940
+Canon,Canon MV950
+Canon,Canon MV960
+Canon,Canon MVX100i
+Canon,Canon MVX10i
+Canon,Canon MVX150i
+Canon,Canon MVX1S
+Canon,Canon MVX200(i)
+Canon,Canon MVX20i
+Canon,Canon MVX250i
+Canon,Canon MVX25i
+Canon,Canon MVX2i
+Canon,Canon MVX300
+Canon,Canon MVX30i
+Canon,Canon MVX330i
+Canon,Canon MVX350i
+Canon,Canon MVX35i
+Canon,Canon MVX3i
+Canon,Canon MVX40
+Canon,Canon MVX450
+Canon,Canon MVX45i
+Canon,Canon MVX460
+Canon,Canon MVX4i
+Canon,Canon MX310 series
+Canon,MX330 series
+Canon,MX700 series
+Canon,MX850 series
+Canon,Canon OPTURA S1
+Canon,Canon OPTURA Xi
+Canon,Canon OPTURA10
+Canon,Canon OPTURA20
+Canon,Canon OPTURA200 MC
+Canon,Canon OPTURA30
+Canon,Canon OPTURA300
+Canon,Canon OPTURA40
+Canon,Canon OPTURA400
+Canon,Canon OPTURA50
+Canon,Canon OPTURA60
+Canon,Canon OPTURA600
+Canon,Canon PowerShot A10
+Canon,Canon PowerShot A100
+Canon,Canon PowerShot A1000 IS
+Canon,Canon PowerShot A1100 IS
+Canon,Canon PowerShot A1200
+Canon,Canon PowerShot A1300
+Canon,Canon PowerShot A1400
+Canon,Canon PowerShot A20
+Canon,Canon PowerShot A200
+Canon,Canon PowerShot A2000 IS
+Canon,Canon PowerShot A2100 IS
+Canon,Canon PowerShot A2200
+Canon,Canon PowerShot A2300
+Canon,Canon PowerShot A2400 IS
+Canon,Canon PowerShot A2500
+Canon,Canon PowerShot A2600
+Canon,Canon PowerShot A30
+Canon,Canon PowerShot A300
+Canon,Canon PowerShot A3000 IS
+Canon,Canon PowerShot A310
+Canon,Canon PowerShot A3100 IS
+Canon,Canon PowerShot A3150 IS
+Canon,Canon PowerShot A3200 IS
+Canon,Canon PowerShot A3300 IS
+Canon,Canon PowerShot A3400IS
+Canon,Canon PowerShot A3500 IS
+Canon,Canon PowerShot A40
+Canon,Canon PowerShot A400
+Canon,Canon PowerShot A4000 IS
+Canon,Canon PowerShot A410
+Canon,Canon PowerShot A420
+Canon,Canon PowerShot A430
+Canon,Canon PowerShot A450
+Canon,Canon PowerShot A460
+Canon,Canon PowerShot A470
+Canon,Canon PowerShot A480
+Canon,Canon PowerShot A490
+Canon,Canon PowerShot A495
+Canon,Canon PowerShot A50
+Canon,Canon PowerShot A510
+Canon,Canon PowerShot A520
+Canon,Canon PowerShot A530
+Canon,Canon PowerShot A540
+Canon,Canon PowerShot A550
+Canon,Canon PowerShot A560
+Canon,Canon PowerShot A570 IS
+Canon,Canon PowerShot A580
+Canon,Canon PowerShot A590 IS
+Canon,Canon PowerShot A60
+Canon,Canon PowerShot A610
+Canon,Canon PowerShot A620
+Canon,Canon PowerShot A630
+Canon,Canon PowerShot A640
+Canon,Canon PowerShot A650 IS
+Canon,Canon PowerShot A70
+Canon,Canon PowerShot A700
+Canon,Canon PowerShot A710 IS
+Canon,Canon PowerShot A720 IS
+Canon,Canon PowerShot A75
+Canon,Canon PowerShot A80
+Canon,Canon PowerShot A800
+Canon,Canon PowerShot A810
+Canon,Canon PowerShot A85
+Canon,Canon PowerShot A95
+Canon,Canon PowerShot D10
+Canon,Canon PowerShot D20
+Canon,Canon PowerShot D30
+Canon,Canon PowerShot E1
+Canon,Canon PowerShot ELPH 100 HS
+Canon,Canon PowerShot ELPH 110 HS
+Canon,Canon PowerShot ELPH 115 IS
+Canon,Canon PowerShot ELPH 120 IS
+Canon,Canon PowerShot ELPH 130 IS
+Canon,Canon PowerShot ELPH 135
+Canon,Canon PowerShot ELPH 140 IS
+Canon,Canon PowerShot ELPH 150 IS
+Canon,Canon PowerShot ELPH 160
+Canon,Canon PowerShot ELPH 170 IS
+Canon,Canon PowerShot ELPH 190 IS
+Canon,Canon PowerShot ELPH 300 HS
+Canon,Canon PowerShot ELPH 310 HS
+Canon,Canon PowerShot ELPH 320 HS
+Canon,Canon PowerShot ELPH 330 HS
+Canon,Canon PowerShot ELPH 340 HS
+Canon,Canon PowerShot ELPH 350 HS
+Canon,Canon PowerShot ELPH 360 HS
+Canon,Canon PowerShot ELPH 500 HS
+Canon,Canon PowerShot ELPH 510 HS
+Canon,Canon PowerShot ELPH 520 HS
+Canon,Canon PowerShot ELPH 530 HS
+Canon,Canon PowerShot G1
+Canon,Canon PowerShot G1 X
+Canon,Canon PowerShot G1 X Mark II
+Canon,Canon PowerShot G1 X Mark III
+Canon,Canon PowerShot G10
+Canon,Canon PowerShot G11
+Canon,Canon PowerShot G12
+Canon,Canon PowerShot G15
+Canon,Canon PowerShot G16
+Canon,Canon PowerShot G2
+Canon,Canon PowerShot G3
+Canon,Canon PowerShot G3 X
+Canon,Canon PowerShot G5
+Canon,Canon PowerShot G5 X
+Canon,Canon PowerShot G5 X Mark II
+Canon,Canon PowerShot G6
+Canon,Canon PowerShot G7
+Canon,Canon PowerShot G7 X
+Canon,Canon PowerShot G7 X Mark II
+Canon,Canon PowerShot G7 X Mark III
+Canon,Canon PowerShot G9
+Canon,Canon PowerShot G9 X
+Canon,Canon PowerShot G9 X Mark II
+Canon,Canon PowerShot N
+Canon,Canon PowerShot N100
+Canon,Canon PowerShot N2
+Canon,Canon PowerShot Pro1
+Canon,Canon PowerShot Pro90 IS
+Canon,Canon PowerShot S1 IS
+Canon,Canon PowerShot S10
+Canon,Canon PowerShot S100
+Canon,Canon PowerShot S110
+Canon,Canon PowerShot S120
+Canon,Canon PowerShot S2 IS
+Canon,Canon PowerShot S20
+Canon,Canon PowerShot S200
+Canon,Canon PowerShot S230
+Canon,Canon PowerShot S3 IS
+Canon,Canon PowerShot S30
+Canon,Canon PowerShot S300
+Canon,Canon PowerShot S330
+Canon,Canon PowerShot S40
+Canon,Canon PowerShot S400
+Canon,Canon PowerShot S410
+Canon,Canon PowerShot S45
+Canon,Canon PowerShot S5 IS
+Canon,Canon PowerShot S50
+Canon,Canon PowerShot S500
+Canon,Canon PowerShot S60
+Canon,Canon PowerShot S70
+Canon,Canon PowerShot S80
+Canon,Canon PowerShot S90
+Canon,Canon PowerShot S95
+Canon,Canon PowerShot SD10
+Canon,Canon PowerShot SD100
+Canon,Canon PowerShot SD1000
+Canon,Canon PowerShot SD110
+Canon,Canon PowerShot SD1100 IS
+Canon,Canon PowerShot SD1200 IS
+Canon,Canon PowerShot SD1300 IS
+Canon,Canon PowerShot SD1400 IS
+Canon,Canon PowerShot SD20
+Canon,Canon PowerShot SD200
+Canon,Canon PowerShot SD30
+Canon,Canon PowerShot SD300
+Canon,Canon PowerShot SD3500 IS
+Canon,Canon PowerShot SD40
+Canon,Canon PowerShot SD400
+Canon,Canon PowerShot SD4000 IS
+Canon,Canon PowerShot SD430 WIRELESS
+Canon,Canon PowerShot SD450
+Canon,Canon PowerShot SD4500 IS
+Canon,Canon PowerShot SD500
+Canon,Canon PowerShot SD550
+Canon,Canon PowerShot SD600
+Canon,Canon PowerShot SD630
+Canon,Canon PowerShot SD700 IS
+Canon,Canon PowerShot SD750
+Canon,Canon PowerShot SD770 IS
+Canon,Canon PowerShot SD780 IS
+Canon,Canon PowerShot SD790 IS
+Canon,Canon PowerShot SD800 IS
+Canon,Canon PowerShot SD850 IS
+Canon,Canon PowerShot SD870 IS
+Canon,Canon PowerShot SD880 IS
+Canon,Canon PowerShot SD890 IS
+Canon,Canon PowerShot SD900
+Canon,Canon PowerShot SD940 IS
+Canon,Canon PowerShot SD950 IS
+Canon,Canon PowerShot SD960 IS
+Canon,Canon PowerShot SD970 IS
+Canon,Canon PowerShot SD980 IS
+Canon,Canon PowerShot SD990 IS
+Canon,Canon PowerShot SX1 IS
+Canon,Canon PowerShot SX10 IS
+Canon,Canon PowerShot SX100 IS
+Canon,Canon PowerShot SX110 IS
+Canon,Canon PowerShot SX120 IS
+Canon,Canon PowerShot SX130 IS
+Canon,Canon PowerShot SX150 IS
+Canon,Canon PowerShot SX160 IS
+Canon,Canon PowerShot SX170 IS
+Canon,Canon PowerShot SX20 IS
+Canon,Canon PowerShot SX200 IS
+Canon,Canon PowerShot SX210 IS
+Canon,Canon PowerShot SX220 HS
+Canon,Canon PowerShot SX230 HS
+Canon,Canon PowerShot SX240 HS
+Canon,Canon PowerShot SX260 HS
+Canon,Canon PowerShot SX270 HS
+Canon,Canon PowerShot SX280 HS
+Canon,Canon PowerShot SX30 IS
+Canon,Canon PowerShot SX40 HS
+Canon,Canon PowerShot SX400 IS
+Canon,Canon PowerShot SX410 IS
+Canon,Canon PowerShot SX420 IS
+Canon,Canon PowerShot SX430 IS
+Canon,Canon PowerShot SX50 HS
+Canon,Canon PowerShot SX500 IS
+Canon,Canon PowerShot SX510 HS
+Canon,Canon PowerShot SX520 HS
+Canon,Canon PowerShot SX530 HS
+Canon,Canon PowerShot SX540 HS
+Canon,Canon PowerShot SX60 HS
+Canon,Canon PowerShot SX600 HS
+Canon,Canon PowerShot SX610 HS
+Canon,Canon PowerShot SX620 HS
+Canon,Canon PowerShot SX70 HS
+Canon,Canon PowerShot SX700 HS
+Canon,Canon PowerShot SX710 HS
+Canon,Canon PowerShot SX720 HS
+Canon,Canon PowerShot SX730 HS
+Canon,Canon PowerShot SX740 HS
+Canon,Canon PowerShot TX1
+Canon,Canon PowerShot V1
+Canon,Canon PowerShot V10
+Canon,Canon PowerShot ZOOM
+Canon,Canon VIXIA HF M30
+Canon,Canon VIXIA HF R10
+Canon,Canon VIXIA HF R100
+Canon,Canon VIXIA HF R11
+Canon,Canon VIXIA HF S10
+Canon,Canon VIXIA HF S100
+Canon,Canon VIXIA HF S200
+Canon,Canon VIXIA HF10
+Canon,Canon VIXIA HF100
+Canon,Canon VIXIA HG21
+Canon,Canon XC10
+Canon,Canon XH A1
+Canon,Canon XH A1S
+Canon,Canon XL H1
+Canon,Canon ZR200
+Canon,Canon ZR300
+Canon,Canon ZR600
+Canon,Canon ZR65 MC
+Canon,Canon ZR70 MC
+Canon,Canon ZR85
+Canon,Canon ZR850
+Canon,Canon ZR90
+Canon,Canon ZR950
+Canon,Canon iR1018/1022/1023
+Canon,Canon iVIS DC50
+Canon,Canon iVIS HF S10
+Canon,Canon iVIS HF10
+Canon,Canon iVIS HR10
+Canon,Canon iVIS HV20
+Caplio,RR330
+"CASIO COMPUTER CO.,LTD.",EX-10
+"CASIO COMPUTER CO.,LTD.",EX-100
+"CASIO COMPUTER CO.,LTD.",EX-F1
+"CASIO COMPUTER CO.,LTD.",EX-FC100
+"CASIO COMPUTER CO.,LTD.",EX-FC150
+"CASIO COMPUTER CO.,LTD.",EX-FC200S
+"CASIO COMPUTER CO.,LTD.",EX-FH100
+"CASIO COMPUTER CO.,LTD.",EX-FH20
+"CASIO COMPUTER CO.,LTD.",EX-FH25
+"CASIO COMPUTER CO., LTD.",EX-FR10
+"CASIO COMPUTER CO.,LTD.",EX-FR100
+"CASIO COMPUTER CO.,LTD.",EX-FS10
+"CASIO COMPUTER CO.,LTD.",EX-G1
+"CASIO COMPUTER CO.,LTD.",EX-H10
+"CASIO COMPUTER CO.,LTD.",EX-H15
+"CASIO COMPUTER CO.,LTD.",EX-H20G
+"CASIO COMPUTER CO.,LTD.",EX-H30
+"CASIO COMPUTER CO.,LTD.",EX-H5
+"CASIO COMPUTER CO.,LTD.",EX-H60
+"CASIO COMPUTER CO.,LTD.",EX-JE10
+"CASIO COMPUTER CO.,LTD.",EX-M1
+"CASIO COMPUTER CO.,LTD.",EX-M2
+"CASIO COMPUTER CO.,LTD",EX-M20
+"CASIO COMPUTER CO.,LTD.",EX-N1
+"CASIO COMPUTER CO.,LTD.",EX-N10
+"CASIO COMPUTER CO.,LTD.",EX-N20
+"CASIO COMPUTER CO.,LTD",EX-P505
+"CASIO COMPUTER CO.,LTD",EX-P600
+"CASIO COMPUTER CO.,LTD",EX-P700
+"CASIO COMPUTER CO.,LTD.",EX-S1
+"CASIO COMPUTER CO.,LTD.",EX-S10
+"CASIO COMPUTER CO.,LTD",EX-S100
+"CASIO COMPUTER CO.,LTD.",EX-S12
+"CASIO COMPUTER CO.,LTD.",EX-S2
+"CASIO COMPUTER CO.,LTD",EX-S20
+"CASIO COMPUTER CO.,LTD.",EX-S200
+"CASIO COMPUTER CO.,LTD",EX-S3
+"CASIO COMPUTER CO.,LTD.",EX-S5
+"CASIO COMPUTER CO.,LTD.",EX-S500
+"CASIO COMPUTER CO.,LTD.",EX-S600
+"CASIO COMPUTER CO.,LTD.",EX-S7
+"CASIO COMPUTER CO.,LTD.",EX-S770
+"CASIO COMPUTER CO.,LTD.",EX-S880
+"CASIO COMPUTER CO.,LTD.",EX-TR100
+"CASIO COMPUTER CO.,LTD.",EX-TR15
+"CASIO COMPUTER CO.,LTD.",EX-TR150
+"CASIO COMPUTER CO.,LTD.",EX-V7
+"CASIO COMPUTER CO.,LTD.",EX-V8
+"CASIO COMPUTER CO.,LTD.",EX-Z1
+"CASIO COMPUTER CO.,LTD.",EX-Z10
+"CASIO COMPUTER CO.,LTD.",EX-Z100
+"CASIO COMPUTER CO.,LTD.",EX-Z1000
+"CASIO COMPUTER CO.,LTD.",EX-Z1050
+"CASIO COMPUTER CO.,LTD.",EX-Z1080
+"CASIO COMPUTER CO.,LTD.",EX-Z11
+"CASIO COMPUTER CO.,LTD.",EX-Z110
+"CASIO COMPUTER CO.,LTD.",EX-Z12
+"CASIO COMPUTER CO.,LTD.",EX-Z120
+"CASIO COMPUTER CO.,LTD.",EX-Z1200
+"CASIO COMPUTER CO.,LTD.",EX-Z15
+"CASIO COMPUTER CO.,LTD.",EX-Z150
+"CASIO COMPUTER CO.,LTD.",EX-Z155
+"CASIO COMPUTER CO.,LTD.",EX-Z16
+"CASIO COMPUTER CO.,LTD.",EX-Z18
+"CASIO COMPUTER CO.,LTD.",EX-Z19
+"CASIO COMPUTER CO.,LTD.",EX-Z2
+"CASIO COMPUTER CO.,LTD.",EX-Z20
+"CASIO COMPUTER CO.,LTD.",EX-Z200
+"CASIO COMPUTER CO.,LTD.",EX-Z2000
+"CASIO COMPUTER CO.,LTD.",EX-Z21
+"CASIO COMPUTER CO.,LTD.",EX-Z22
+"CASIO COMPUTER CO.,LTD.",EX-Z2300
+"CASIO COMPUTER CO.,LTD.",EX-Z250
+"CASIO COMPUTER CO.,LTD.",EX-Z270
+"CASIO COMPUTER CO.,LTD.",EX-Z280
+"CASIO COMPUTER CO.,LTD.",EX-Z29
+"CASIO COMPUTER CO.,LTD",EX-Z3
+"CASIO COMPUTER CO.,LTD",EX-Z30
+"CASIO COMPUTER CO.,LTD.",EX-Z300
+"CASIO COMPUTER CO.,LTD.",EX-Z3000
+"CASIO COMPUTER CO.,LTD.",EX-Z33
+"CASIO COMPUTER CO.,LTD.",EX-Z330
+"CASIO COMPUTER CO.,LTD.",EX-Z35
+"CASIO COMPUTER CO.,LTD.",EX-Z350
+"CASIO COMPUTER CO.,LTD.",EX-Z37
+"CASIO COMPUTER CO.,LTD",EX-Z4
+"CASIO COMPUTER CO.,LTD",EX-Z40
+"CASIO COMPUTER CO.,LTD.",EX-Z400
+"CASIO COMPUTER CO.,LTD.",EX-Z450
+"CASIO COMPUTER CO.,LTD.",EX-Z5
+"CASIO COMPUTER CO.,LTD",EX-Z50
+"CASIO COMPUTER CO.,LTD.",EX-Z500
+"CASIO COMPUTER CO.,LTD",EX-Z55
+"CASIO COMPUTER CO.,LTD.",EX-Z550
+"CASIO COMPUTER CO.,LTD",EX-Z57
+"CASIO COMPUTER CO.,LTD.",EX-Z6
+"CASIO COMPUTER CO.,LTD.",EX-Z60
+"CASIO COMPUTER CO.,LTD.",EX-Z600
+"CASIO COMPUTER CO.,LTD.",EX-Z65
+"CASIO COMPUTER CO.,LTD.",EX-Z7
+"CASIO COMPUTER CO.,LTD.",EX-Z70
+"CASIO COMPUTER CO.,LTD.",EX-Z700
+"CASIO COMPUTER CO.,LTD.",EX-Z75
+"CASIO COMPUTER CO.,LTD",EX-Z750
+"CASIO COMPUTER CO.,LTD.",EX-Z77
+"CASIO COMPUTER CO.,LTD.",EX-Z8
+"CASIO COMPUTER CO.,LTD.",EX-Z80
+"CASIO COMPUTER CO.,LTD.",EX-Z800
+"CASIO COMPUTER CO.,LTD.",EX-Z85
+"CASIO COMPUTER CO.,LTD.",EX-Z850
+"CASIO COMPUTER CO.,LTD.",EX-Z9
+"CASIO COMPUTER CO.,LTD.",EX-Z90
+"CASIO COMPUTER CO.,LTD.",EX-ZR10
+"CASIO COMPUTER CO.,LTD.",EX-ZR100
+"CASIO COMPUTER CO.,LTD.",EX-ZR1000
+"CASIO COMPUTER CO.,LTD.",EX-ZR1200
+"CASIO COMPUTER CO.,LTD.",EX-ZR15
+"CASIO COMPUTER CO.,LTD.",EX-ZR1500
+"CASIO COMPUTER CO.,LTD.",EX-ZR1600
+"CASIO COMPUTER CO.,LTD.",EX-ZR20
+"CASIO COMPUTER CO.,LTD.",EX-ZR200
+"CASIO COMPUTER CO.,LTD.",EX-ZR2000
+"CASIO COMPUTER CO.,LTD.",EX-ZR300
+"CASIO COMPUTER CO.,LTD.",EX-ZR3500
+"CASIO COMPUTER CO.,LTD.",EX-ZR50
+"CASIO COMPUTER CO.,LTD.",EX-ZR500
+"CASIO COMPUTER CO.,LTD.",EX-ZR800
+"CASIO COMPUTER CO.,LTD.",EX-ZR850
+"CASIO COMPUTER CO.,LTD.",EX-ZS10
+"CASIO COMPUTER CO.,LTD.",EX-ZS100
+"CASIO COMPUTER CO.,LTD.",EX-ZS12
+"CASIO COMPUTER CO.,LTD.",EX-ZS15
+"CASIO COMPUTER CO.,LTD.",EX-ZS150
+"CASIO COMPUTER CO.,LTD.",EX-ZS180
+"CASIO COMPUTER CO.,LTD.",EX-ZS20
+"CASIO COMPUTER CO.,LTD.",EX-ZS27
+"CASIO COMPUTER CO.,LTD.",EX-ZS30
+"CASIO COMPUTER CO.,LTD.",EX-ZS5
+"CASIO COMPUTER CO.,LTD.",EX-ZS50
+"CASIO COMPUTER CO.,LTD.",EX-ZS6
+CASIO,G'z One Type-V
+CASIO,G'zOne Boulder
+CASIO,GV-10
+CASIO,GV-20
+"CASIO COMPUTER CO.,LTD.",KX-850
+CASIO,QV-2000UX
+CASIO,QV-2100
+CASIO,QV-2300UX
+CASIO,QV-2400UX
+CASIO,QV-2800UX
+CASIO,QV-2900UX
+CASIO,QV-3000EX
+CASIO,QV-3500EX
+CASIO,QV-3EX
+CASIO,QV-4000
+CASIO,QV-5700
+CASIO,QV-8000SX
+"CASIO COMPUTER CO.,LTD.",QV-R100
+"CASIO COMPUTER CO.,LTD.",QV-R200
+"CASIO COMPUTER CO.,LTD.",QV-R3
+"CASIO COMPUTER CO.,LTD.",QV-R4
+"CASIO COMPUTER CO.,LTD",QV-R40
+"CASIO COMPUTER CO.,LTD",QV-R41
+"CASIO COMPUTER CO.,LTD",QV-R51
+"CASIO COMPUTER CO.,LTD",QV-R52
+"CASIO COMPUTER CO.,LTD",QV-R61
+"CASIO COMPUTER CO.,LTD",QV-R62
+CASIO,XV-3
+"CASIO COMPUTER CO.,LTD",YC-400
+Concord Camera Corp.,EYE_Q3040
+Concord Camera Corp.,EYE_Q3042
+Concord Camera Corp.,Eye-Q 3340z
+Concord Camera Corp.,Eye-Q 3341Z
+Concord Camera Corp.,Eye-Q 4060 AF
+Concord Camera Corp.,Eye-Q 4360Z
+Concord Camera Corp.,Eye-Q 4363Z
+Concord Camera Corp.,Eye-Q 5062AF
+Concord camera Corp,EyeQ 3103
+Concord Camera Corp.,EyeQ 3132z
+Concord Camera GmbH,JD 10.0z3 EasyShot
+Concord Camera GmbH,JD 5.0z3 EasyShot
+Concord Camera GmbH,JD 6.0z3 EasyShot
+Concord Camera GmbH,JD 8.0
+Concord Camera GmbH,JDC 3.0C
+Concord Camera GmbH,JDC 3.0S
+Concord Camera Corp.,JM Multimedia
+Concord Camera GmbH,Jenoptik JD 3.1 exclusiv
+Concord Camera GmbH,Jenoptik JD 4360z
+Concord Camera GmbH,Jenoptik JD 4363z
+Concord Camera GmbH,Jenoptik JD 5.2 zoom
+Concord Corporation,Concord 2000
+Concord Camera Corp.,Concord 4340z
+Concord Camera Corp.,Concord 5040
+Concord Camera Corp.,Concord 5340z
+Concord Camera Corp.,Concord 6340z
+Concord Camera Corp.,Concord Eye-Q 3345z
+Concord Camera Corp.,Concord Eye-Q 3346z
+Corelogic,SAMSUNG SGH-T809
+Creative,Creative DC-CAM 3000Z
+Creative,DC-CAM 3200Z
+Creative Labs,DiVi CAM 516
+Creative Labs,DiVi CAM 525D
+Creative Labs,DiVi Cam 428
+Creative Labs,DiViCam 316
+Creative Labs,PC Cam 930 Slim
+Creative Labs,PC Cam 950 Slim
+Creative,Creative PC-CAM 900
+Creative Technology Ltd.,CR530
+Creative Technology Ltd.,CR780
+Creative Technology Ltd.,CR781
+Creative,Vado HD
+,CONCORD 3045
+D-Link,DCS-825L
+?,DC2320
+DEFAULT,SLIM5L
+DEFAULT,SLIMX5
+"DXG TECHNOLOGY CO., LTD.",010101
+DXG TECH CORP,DCS711
+DXG Company,DSC
+"DXG TECHNOLOGY CO., LTD.",DSC502
+DXG,DSC608
+DXG Corporation.,DXG 409
+"DXG Technologies,Inc.",DXG DZ358
+DXG Technology Corp.,DXG106
+DXG Technology Co. Ltd.,FashionCam
+DJI,FC1102
+DJI,FC220
+DJI,FC2204
+DJI,FC300C
+DJI,FC300S
+DJI,FC300X
+DJI,FC300XW
+DJI,FC330
+DJI,FC6310
+DJI,FC7203
+DJI,FC7303
+DJI,FLIR
+DJI,M30T
+DJI,M3T
+DJI,MAVIC2-ENTERPRISE-ADVANCED
+DJI,PHANTOM VISION FC200
+DJI,DJI Pocket
+DJI,XT S
+DJI,XT2
+DJI,ZH20N
+DS GLOBAL,POLSP01
+,DSC
+DSC,DDC-690
+,DV
+,DXG528
+Daisy Multimedia,?
+Daisy Multimedia,DM2100a
+Daisy Multimedia,DM334
+Daisy Multimedia,DM334SF
+Daisy Multimedia Ltd,DM425Zr
+Daisy Multimedia,PH8300
+Daisy Multimedia,PhC60XX
+Daisy Multimedia,PhC70XX
+DigiCam,DC 1070
+DIGILIFE,DDC-580
+DigiLife,DDC-680
+Samsung Techwin,"<Digimax i5, Samsung #1>"
+Samsung Techwin,"<Digimax i50 MP3, Samsung #1 MP3>"
+Samsung Techwin,"<Digimax i6 PMP, Samsung #11 PMP>"
+Digital,Digital Camera
+Digital MultiCam II,Moultrie Game Camera
+DoCoMo,D251i
+DoCoMo,D251iS
+DoCoMo,D252i
+DoCoMo,D253iWM
+DoCoMo,D505i
+DoCoMo,D505iS
+DoCoMo,D506i
+DoCoMo,D900i
+DoCoMo,D901i
+DoCoMo,D903i
+DoCoMo,D904i
+DoCoMo,D905i
+DoCoMo,F2102V
+DoCoMo,F505i
+DoCoMo,F505iGPS
+DoCoMo,F506i
+DoCoMo,F900i
+DoCoMo,F900iC
+DoCoMo,F900iT
+DoCoMo,F901iC
+DoCoMo,F904i
+DoCoMo,F905i
+DOCOMO,M702iG
+DoCoMo,N01A
+DoCoMo,N505i
+DoCoMo,N505iS
+DoCoMo,N506i
+DoCoMo,N506iS
+DoCoMo,N700i
+DoCoMo,N703iD
+DoCoMo,N900i
+DoCoMo,N900iS
+DoCoMo,N901iC
+DoCoMo,N904i
+DoCoMo,N905i
+DoCoMo,N906imyu
+DoCoMo,P2102V
+DoCoMo,P252i
+DoCoMo,P252iS
+DoCoMo,P253i
+DoCoMo,P505i
+DoCoMo,P505iS
+DoCoMo,P506iC
+DoCoMo,P700i
+DoCoMo,P705i
+DoCoMo,P900i
+DoCoMo,P900iV
+DoCoMo,P901i
+DoCoMo,P903i
+DoCoMo,P905i
+DoCoMo,SH01A
+DoCoMo,SH03A
+DoCoMo,SH06A
+DoCoMo,SH505i
+DoCoMo,SH505iS
+DoCoMo,SH506iC
+DoCoMo,SH700i
+DoCoMo,SH702iD
+DoCoMo,SH703i
+DoCoMo,SH900i
+DoCoMo,SH901iC
+DoCoMo,SH902i
+DoCoMo,SH903i
+DoCoMo,SH903iTV
+DoCoMo,SH904i
+DoCoMo,SH905i
+DoCoMo,SO505i
+DoCoMo,SO505iS
+DoCoMo,SO506i
+DoCoMo,SO506iC
+DoCoMo,SO902i
+DoCoMo,SO903i
+DoCoMo,SO905iCS
+NTT DoCoMo,eggy
+DxO,DxO ONE
+ES.M550,SPH-M550
+ES.M810,SPH-M810
+SEIKO EPSON CORP.,CP-800
+SEIKO EPSON CORP.,CP-800S
+SEIKO EPSON CORP.,CP-80Z
+SEIKO EPSON CORP.,CP-850Z
+SEIKO EPSON CORP.,CP-900Z
+SEIKO EPSON CORP.,CP-920Z
+EPSON,EPSON CX3900/CX4000/DX4000
+Epson,CX4400
+Epson,Exp10000XL
+SEIKO EPSON CORP.,L-300
+SEIKO EPSON CORP.,L-400
+SEIKO EPSON CORP.,L-410
+SEIKO EPSON CORP.,L-500V
+Epson,Perfection1250
+Epson,Perfection1660
+Epson,Perfection2480
+Epson,Perfection4990
+Epson,PerfectionV100
+Epson,Epson Perfection V500 Photo Scanner
+Epson,Perfection V500 Photo Scanner
+Epson,PerfectionV700
+SEIKO EPSON CORP.,PhotoPC 2100Z
+SEIKO EPSON CORP.,PhotoPC 3000Z
+SEIKO EPSON CORP.,PhotoPC 3100Z
+SEIKO EPSON CORP.,PhotoPC 800
+SEIKO EPSON CORP.,PhotoPC 800S
+SEIKO EPSON CORP.,PhotoPC 850Z
+SEIKO EPSON CORP.,R-D1
+SEIKO EPSON CORP.,R-D1s
+SEIKO EPSON CORP.,Stylus Photo RX590
+SEIKO EPSON CORP.,Stylus Photo RX610
+SEIKO EPSON CORP.,Stylus Photo RX620
+SEIKO EPSON CORP.,Stylus Photo RX640
+SEIKO EPSON CORP.,Stylus Photo RX690
+SEIKO EPSON CORP.,Stylus Photo RX700
+FLIR Systems,
+FLIR Systems AB,*
+FLIR Systems,FLIR AX5
+FLIR Systems AB,FLIR B335
+FLIR Systems AB,Bertha3
+FLIR,Duo Pro R
+FLIR Systems AB,FLIR E30
+FLIR Systems AB,FLIR E30bx
+FLIR Systems AB,FLIR E4
+FLIR Systems AB,FLIR E40
+FLIR Systems AB,FLIR E40bx
+FLIR Systems AB,FLIR E5
+FLIR Systems,FLIR E50
+Teledyne FLIR,FLIR E54
+FLIR Systems AB,FLIR E6
+FLIR Systems AB,FLIR E60
+FLIR Systems AB,FLIR E76
+FLIR Systems AB,FLIR E8
+FLIR Systems AB,FLIR ONE Pro
+FLIR Systems AB,P20 NTSC
+FLIR Systems AB,P25 PAL
+FLIR Systems AB,P60
+FLIR Systems AB,P60 NTSC
+FLIR Systems AB,P60 PAL
+FLIR Systems AB,FLIR P640
+FLIR Systems AB,FLIR P660
+FLIR Systems AB,S65 NTSC
+FLIR Systems AB,FLIR T250_ Western
+FLIR Systems AB,FLIR T360_ Western
+FLIR Systems AB,FLIR T400
+FLIR Systems AB,FLIR T400 Western
+FLIR Systems AB,FLIR T420
+FLIR Systems AB,FLIR T425
+FLIR Systems AB,FLIR T620
+FLIR Systems AB,FLIR T620bx
+FLIR Systems AB,FLIR T630sc
+FLIR Systems AB,FLIR T640
+FLIR,TAU2
+FLIR Systems AB,ThermaCAM A320
+FLIR Systems AB,ThermaCAM B-360 Wes
+FLIR Systems AB,ThermaCAM E2
+FLIR Systems AB,ThermaCAM E320
+FLIR Systems AB,ThermaCAM E45
+FLIR Systems AB,ThermaCAM E65
+FLIR Systems AB,ThermaCAM EX320
+FLIR Systems,ThermaCAM P640
+FLIR Systems AB,ThermaCAM P660 West
+FLIR Systems AB,ThermaCAM SC640
+FLIR Systems AB,ThermaCAM SC660 Wes
+FLIR Systems AB,ThermaCAM T-400
+FLIR Systems AB,ThermaCam P660 Wes
+FLIR Systems AB,ThermaCam SC660 WES
+FLIR Systems AB,Z-CAMERA
+FLIR Systems AB,Flir b40
+FLIR Systems AB,Flir b50
+FLIR Systems AB,FLIR i5
+FLIR Systems AB,Flir i50
+FLIR Systems AB,Flir i60
+FLIR Systems AB,FLIR_i3
+FLIR Systems AB,FLIR_i7
+Fly,E105
+Fly,Fly E125
+Fly,Fly E155
+Fly,Fly E300
+Fly,Fly LX500
+Fly,Fly LX600
+Fly,SX100
+Fly,Fly SX210
+FUJIFILM,A100
+FUJIFILM,A150
+FUJIFILM,Fujifilm A170
+FUJIFILM,Fujifilm A170 A180
+FUJIFILM,Fujifilm A220
+FUJIFILM,Fujifilm A220 A230
+FUJIFILM,A850
+FUJIFILM,CLIP-IT50
+FUJIFILM,CLIP-IT80
+FUJIFILM,DS-10
+FUJIFILM,DS-20
+FUJIFILM,DS-220
+FUJIFILM,DS-230HD
+FUJIFILM,DS-250
+FUJIFILM,DS-260HD
+FUJIFILM,DS-270HD
+FUJIFILM,DS-30
+FUJIFILM,DS-300
+FUJIFILM,DS-7
+FUJIFILM,DS-8
+FUJIFILM,DX-10
+FUJIFILM,DX-5
+FUJIFILM,DX-7
+FUJIFILM,DX-8
+FUJIFILM,DX-9
+FUJIFILM,Digital Q1
+FUJIFILM,Digital Q1 3M
+FUJIFILM,FI019
+FUJIFILM,FinePix1200
+FUJIFILM,FinePix1300
+FUJIFILM,FinePix1400Zoom
+FUJIFILM,FinePix1500
+FUJIFILM,FinePix1700Z
+FUJIFILM,FinePix2200
+FUJIFILM,FinePix2300
+FUJIFILM,FinePix2400Zoom
+FUJIFILM,FinePix2500Z
+FUJIFILM,FinePix2600Zoom
+FUJIFILM,FinePix2650
+FUJIFILM,FinePix2700
+FUJIFILM,FinePix2800ZOOM
+FUJIFILM,FinePix2900Z
+FUJIFILM,FinePix30i
+FUJIFILM,FinePix 3800
+FUJIFILM,FinePix40i
+FUJIFILM,FinePix4500
+FUJIFILM,FinePix4700 ZOOM
+FUJIFILM,FinePix4800 ZOOM
+FUJIFILM,FinePix4900ZOOM
+FUJIFILM,FinePix500
+FUJIFILM,FinePix50i
+FUJIFILM,FinePix600Z
+FUJIFILM,FinePix6800 ZOOM
+FUJIFILM,FinePix6900ZOOM
+FUJIFILM,FinePix700
+FUJIFILM,FinePixA101
+FUJIFILM,FinePix A120
+FUJIFILM,FinePix A200
+FUJIFILM,FinePixA201
+FUJIFILM,FinePix A202
+FUJIFILM,FinePix A203
+FUJIFILM,FinePixA204
+FUJIFILM,FinePix A205
+FUJIFILM,FinePix A205S
+FUJIFILM,FinePix A210
+FUJIFILM,FinePix A303
+FUJIFILM,FinePix A310
+FUJIFILM,FinePix A330
+FUJIFILM,FinePix A340
+FUJIFILM,FinePix A345
+FUJIFILM,FinePix A350
+FUJIFILM,FinePix A360
+FUJIFILM,FinePix A370
+FUJIFILM,FinePix A400
+FUJIFILM,FinePix A403
+FUJIFILM,FinePix A405
+FUJIFILM,FinePix A500
+FUJIFILM,FinePix A510
+FUJIFILM,FinePix A600
+FUJIFILM,FinePix A605
+FUJIFILM,FinePix A607
+FUJIFILM,FinePix A610
+FUJIFILM,FinePix A700
+FUJIFILM,FinePix A800
+FUJIFILM,FinePix A805
+FUJIFILM,FinePix A820
+FUJIFILM,FinePix A900
+FUJIFILM,FinePix A920
+FUJIFILM,FinePix AV100
+FUJIFILM,FinePix AV100 AV110
+FUJIFILM,FinePix AV105
+FUJIFILM,FinePix AV110
+FUJIFILM,FinePix AV120
+FUJIFILM,FinePix AV130
+FUJIFILM,FinePix AV150
+FUJIFILM,FinePix AV180
+FUJIFILM,FinePix AV200
+FUJIFILM,FinePix AV230
+FUJIFILM,FinePix AV250
+FUJIFILM,FinePix AV280
+FUJIFILM,FinePix AX200
+FUJIFILM,FinePix AX205
+FUJIFILM,FinePix AX230
+FUJIFILM,FinePix AX245w
+FUJIFILM,FinePix AX250
+FUJIFILM,FinePix AX280
+FUJIFILM,FinePix AX300
+FUJIFILM,FinePix AX330
+FUJIFILM,FinePix AX350
+FUJIFILM,FinePix AX380
+FUJIFILM,FinePix AX550
+FUJIFILM,FinePix BIGJOB HD-3W
+FUJIFILM,FinePix E500
+FUJIFILM,FinePix E510
+FUJIFILM,FinePix E550
+FUJIFILM,FinePix E900
+FUJIFILM,FinePix F10
+FUJIFILM,FinePix F100fd
+FUJIFILM,FinePix F11
+FUJIFILM,FinePix F20
+FUJIFILM,FinePix F200EXR
+FUJIFILM,FinePix F30
+FUJIFILM,FinePix F300EXR
+FUJIFILM,FinePix F31fd
+FUJIFILM,FinePix F401
+FUJIFILM,FinePix F402
+FUJIFILM,FinePix F40fd
+FUJIFILM,FinePix F410
+FUJIFILM,FinePix F420
+FUJIFILM,FinePix F440
+FUJIFILM,FinePix F450
+FUJIFILM,FinePix F455
+FUJIFILM,FinePix F45fd
+FUJIFILM,FinePix F460
+FUJIFILM,FinePix F470
+FUJIFILM,FinePix F47fd
+FUJIFILM,FinePix F480
+FUJIFILM,FinePix F500EXR
+FUJIFILM,FinePix F505EXR
+FUJIFILM,FinePix F50SE
+FUJIFILM,FinePix F50fd
+FUJIFILM,FinePix F550EXR
+FUJIFILM,FinePix F600EXR
+FUJIFILM,FinePix F601
+FUJIFILM,FinePix F601 ZOOM
+FUJIFILM,FinePix F605EXR
+FUJIFILM,FinePix F60fd
+FUJIFILM,FinePix F610
+FUJIFILM,FinePix F650
+FUJIFILM,FinePix F660EXR
+FUJIFILM,FinePix F700
+FUJIFILM,FinePix F70EXR
+FUJIFILM,FinePix F710
+FUJIFILM,FinePix F750EXR
+FUJIFILM,FinePix F770EXR
+FUJIFILM,FinePix F800EXR
+FUJIFILM,FinePix F80EXR
+FUJIFILM,FinePix F810
+FUJIFILM,FinePix F85EXR
+FUJIFILM,FinePix F900EXR
+FUJIFILM,FinePix HS10 HS11
+FUJIFILM,FinePix HS20EXR
+FUJIFILM,FinePix HS25EXR
+FUJIFILM,FinePix HS28EXR
+FUJIFILM,FinePix HS30EXR
+FUJIFILM,FinePix HS33EXR
+FUJIFILM,FinePix HS35EXR
+FUJIFILM,FinePix HS50EXR
+FUJIFILM,FinePix J10
+FUJIFILM,FinePix J100
+FUJIFILM,FinePix J110W
+FUJIFILM,FinePix J12
+FUJIFILM,FinePix J120
+FUJIFILM,FinePix J150W
+FUJIFILM,FinePix J15fd
+FUJIFILM,FinePix J20
+FUJIFILM,FinePix J210
+FUJIFILM,FinePix J250
+FUJIFILM,FinePix J27 J28 J29
+FUJIFILM,FinePix J30
+FUJIFILM,FinePix J30 J32 J38
+FUJIFILM,FinePix J50
+FUJIFILM,FinePix JV100
+FUJIFILM,FinePix JV100 JV110
+FUJIFILM,FinePix JV110
+FUJIFILM,FinePix JV150
+FUJIFILM,FinePix JV160
+FUJIFILM,FinePix JV170
+FUJIFILM,FinePix JV200
+FUJIFILM,FinePix JV250
+FUJIFILM,FinePix JX200
+FUJIFILM,FinePix JX210
+FUJIFILM,FinePix JX250
+FUJIFILM,FinePix JX280
+FUJIFILM,FinePix JX300
+FUJIFILM,FinePix JX350
+FUJIFILM,FinePix JX370
+FUJIFILM,FinePix JX400
+FUJIFILM,FinePix JX420
+FUJIFILM,FinePix JX500
+FUJIFILM,FinePix JX530
+FUJIFILM,FinePix JX580
+FUJIFILM,FinePix JZ100/JZ110
+FUJIFILM,FinePix JZ250/JZ260
+FUJIFILM,FinePix JZ300
+FUJIFILM,FinePix JZ305
+FUJIFILM,FinePix JZ310
+FUJIFILM,FinePix JZ500
+FUJIFILM,FinePix JZ505
+FUJIFILM,FinePix JZ510
+FUJIFILM,FinePix M603
+FUJIFILM,FinePixPR21
+FUJIFILM,FinePix REAL 3D W1
+FUJIFILM,FinePix REAL 3D W3
+FUJIFILM,FinePix S1
+FUJIFILM,FinePix S1000fd
+FUJIFILM,FinePix S100FS
+FUJIFILM,FinePix S1500
+FUJIFILM,FinePix S1600
+FUJIFILM,FinePix S1700
+FUJIFILM,FinePix S1730
+FUJIFILM,FinePix S1770
+FUJIFILM,FinePix S1800
+FUJIFILM,FinePix S1850
+FUJIFILM,FinePix S1900
+FUJIFILM,FinePixS1Pro
+FUJIFILM,FinePix S2000HD
+FUJIFILM,FinePix S2000HD S2100HD
+FUJIFILM,FinePix S200EXR
+FUJIFILM,FinePix S205EXR
+FUJIFILM,FinePix S20Pro
+FUJIFILM,FinePix S2500HD
+FUJIFILM,FinePix S2550HD
+FUJIFILM,FinePix S2600HD
+FUJIFILM,FinePix S2800HD
+FUJIFILM,FinePix S2950
+FUJIFILM,FinePix S2980
+FUJIFILM,FinePixS2Pro
+FUJIFILM,FinePix S3000
+FUJIFILM,FinePix S304
+FUJIFILM,FinePix S3100
+FUJIFILM,FinePix S3200
+FUJIFILM,FinePix S3300
+FUJIFILM,FinePix S3400
+FUJIFILM,FinePix S3500
+FUJIFILM,FinePix S3Pro
+FUJIFILM,FinePix S4000
+FUJIFILM,FinePix S4200
+FUJIFILM,FinePix S4300
+FUJIFILM,FinePix S4400
+FUJIFILM,FinePix S4500
+FUJIFILM,FinePix S4800
+FUJIFILM,FinePix S5000
+FUJIFILM,FinePix S5100
+FUJIFILM,FinePix S5200
+FUJIFILM,FinePix S5500
+FUJIFILM,FinePix S5600
+FUJIFILM,FinePix S5700 S700
+FUJIFILM,FinePix S5800 S800
+FUJIFILM,FinePix S5Pro
+FUJIFILM,FinePix S6000fd
+FUJIFILM,FinePix S602
+FUJIFILM,FinePix S602 ZOOM
+FUJIFILM,FinePix S6500fd
+FUJIFILM,FinePix S7000
+FUJIFILM,FinePix S8000fd
+FUJIFILM,FinePix S8100fd
+FUJIFILM,FinePix S8200
+FUJIFILM,FinePix S8300
+FUJIFILM,FinePix S8400W
+FUJIFILM,FinePix S8500
+FUJIFILM,FinePix S9000
+FUJIFILM,FinePix S9100
+FUJIFILM,FinePix S9200 S9250 S9150
+FUJIFILM,FinePix S9400W S9450W
+FUJIFILM,FinePix S9500
+FUJIFILM,FinePix S9600
+FUJIFILM,FinePix S9800 S9850 S9750
+FUJIFILM,FinePix S9900W S9950W
+FUJIFILM,FinePix SL1000
+FUJIFILM,FinePix SL240
+FUJIFILM,FinePix SL260
+FUJIFILM,FinePix SL280
+FUJIFILM,FinePix SL300
+FUJIFILM,FinePix T200
+FUJIFILM,FinePix T300
+FUJIFILM,FinePix T350
+FUJIFILM,FinePix T400
+FUJIFILM,FinePix T500
+FUJIFILM,FinePix T550
+FUJIFILM,FinePix V10
+FUJIFILM,FinePixViewer Ver.4.2
+FUJIFILM,FinePix X100
+FUJIFILM,FinePix XP10
+FUJIFILM,FinePix XP100
+FUJIFILM,FinePix XP120 XP121 XP125
+FUJIFILM,FinePix XP130 XP131 XP135
+FUJIFILM,FinePix XP140 XP141 XP145
+FUJIFILM,FinePix XP150
+FUJIFILM,FinePix XP170
+FUJIFILM,FinePix XP20
+FUJIFILM,FinePix XP200/XP210
+FUJIFILM,FinePix XP30
+FUJIFILM,FinePix XP50
+FUJIFILM,FinePix XP60
+FUJIFILM,FinePix XP70 XP71 XP75
+FUJIFILM,FinePix XP80 XP81 XP85
+FUJIFILM,FinePix XP90 XP91 XP95
+FUJIFILM,FinePix Z1
+FUJIFILM,FinePix Z1000EXR
+FUJIFILM,FinePix Z100fd
+FUJIFILM,FinePix Z10fd
+FUJIFILM,FinePix  Z110
+FUJIFILM,FinePix Z2
+FUJIFILM,FinePix Z200fd
+FUJIFILM,FinePix Z20fd
+FUJIFILM,FinePix Z250fd
+FUJIFILM,FinePix Z3
+FUJIFILM,FinePix Z30
+FUJIFILM,FinePix Z300
+FUJIFILM,FinePix Z31
+FUJIFILM,FinePix Z33WP
+FUJIFILM,FinePix Z35
+FUJIFILM,FinePix Z37
+FUJIFILM,FinePix Z5fd
+FUJIFILM,FinePix Z70
+FUJIFILM,FinePix Z700EXR
+FUJIFILM,FinePix Z707EXR
+FUJIFILM,FinePix Z80
+FUJIFILM,FinePix Z800EXR
+FUJIFILM,FinePix Z90
+FUJIFILM,FinePix Z900EXR
+FUJIFILM,FinePix Z950EXR
+FUJIFILM,GFX 100
+FUJIFILM,GFX 50R
+FUJIFILM,GFX 50S
+FUJIFILM,GFX100 II
+FUJIFILM,GFX100RF
+FUJIFILM,GFX100S
+FUJIFILM,GFX100S II
+FUJIFILM,GFX50S II
+FUJIFILM,IS-1
+FUJIFILM,MX-1200
+FUJIFILM,MX-1500
+FUJIFILM,MX-1700ZOOM
+FUJIFILM,MX-2700
+FUJIFILM,MX-2900ZOOM
+FUJIFILM,MX-500
+FUJIFILM,MX-600ZOOM
+FUJIFILM,MX-700
+"FUJI PHOTO FILM CO., LTD.",SLP1000SE
+"FUJI PHOTO FILM CO., LTD.",SLP800
+"FUJI PHOTO FILM CO., LTD.",SP-1000-2780091-01
+"FUJI PHOTO FILM CO., LTD.",SP-1500
+"FUJI PHOTO FILM CO., LTD.",SP-2000
+"FUJI PHOTO FILM CO., LTD.",SP-2500
+"FUJI PHOTO FILM CO., LTD.",SP500
+FUJIFILM,SQ10
+FUJIFILM,SQ20
+FUJIFILM,X-A1
+FUJIFILM,X-A10
+FUJIFILM,X-A2
+FUJIFILM,X-A3
+FUJIFILM,X-A5
+FUJIFILM,X-A7
+FUJIFILM,X-E1
+FUJIFILM,X-E2
+FUJIFILM,X-E2S
+FUJIFILM,X-E3
+FUJIFILM,X-E4
+FUJIFILM,X-E5
+FUJIFILM,X-H1
+FUJIFILM,X-H2
+FUJIFILM,X-H2S
+FUJIFILM,X-HF1
+FUJIFILM,X-M1
+FUJIFILM,X-M5
+FUJIFILM,X-Pro1
+FUJIFILM,X-Pro2
+FUJIFILM,X-Pro3
+FUJIFILM,X-S1
+FUJIFILM,X-S10
+FUJIFILM,X-S20
+FUJIFILM,X-T1
+FUJIFILM,X-T10
+FUJIFILM,X-T100
+FUJIFILM,X-T2
+FUJIFILM,X-T20
+FUJIFILM,X-T200
+FUJIFILM,X-T3
+FUJIFILM,X-T30
+FUJIFILM,X-T4
+FUJIFILM,X-T5
+FUJIFILM,X-T50
+FUJIFILM,X10
+FUJIFILM,X100F
+FUJIFILM,X100S
+FUJIFILM,X100T
+FUJIFILM,X100V
+FUJIFILM,X100VI
+FUJIFILM,X20
+FUJIFILM,X30
+FUJIFILM,X70
+FUJIFILM,XF1
+FUJIFILM,XF10
+FUJIFILM,XQ1
+FUJIFILM,XQ2
+GE,X600
+GEDSC IMAGING CORP.,A735
+GEDSC IMAGING CORP.,A835
+Garmin,DashCam
+Garmin,VIRB 360
+"  (C) 2003 Gateway,Inc.",DC-M40
+Gateway,DC-M42
+"(C) 2003 Gateway,Inc.",DC-M50
+Gateway,DC-T50
+GATEWAY,DV-S20
+General Imaging Co.,A1030
+GENERAL IMAGING CO.,A1050
+GENERAL IMAGING CO.,A1150
+General Imaging Co.,A1200
+General Imaging Co.,A1230
+GENERAL IMAGING CO.,A1250
+General Imaging Co.,A730
+General Imaging Co.,A830
+GENERAL IMAGING CO.,A950
+GENERAL IMAGING CO.,C1233
+GENERAL IMAGING CO.,C1433
+General Imaging Co.,E1030
+General Imaging Co.,E1035
+General Imaging Co.,E1040
+GENERAL IMAGING CO.,E1050 TW
+General Imaging Co.,E1235
+GENERAL IMAGING CO.,E1250 TW
+GENERAL IMAGING CO.,E1255W
+GENERAL IMAGING CO.,E1410SW
+GENERAL IMAGING CO.,E1486 TW
+GENERAL IMAGING CO.,E1680W
+General Imaging Co.,E840s
+General Imaging Co.,E850
+General Imaging Co.,G1
+GENERAL IMAGING CO.,G100
+General Imaging Co.,G2
+GENERAL IMAGING CO.,G3WP
+GENERAL IMAGING CO.,J1455
+GENERAL IMAGING CO.,J1470S
+GENERAL IMAGING CO.,X400
+GENERAL IMAGING CO.,X5
+GENERAL IMAGING CO.,X500
+GENERAL IMAGING CO.,X550
+Genius,DV210
+Genius,G-Shot P850
+Genius,G-Shot V3
+Genius,GShot312
+Genius,GShot511
+GoPro,GoPro Fusion
+GoPro,HD2
+Gopro,HD3
+GoPro,HERO
+GoPro,HERO+
+GoPro,HERO+ LCD
+GoPro,HERO10 Black
+GoPro,HERO11 Black
+GoPro,HERO12 Black
+GoPro,HERO3+ Black Edition
+GoPro,HERO3+ Silver Edition
+GoPro,HERO4 Black
+GoPro,HERO4 Session
+GoPro,HERO4 Silver
+GoPro,HERO5 Black
+GoPro,HERO5 Session
+GoPro,HERO6 Black
+GoPro,HERO7 Black
+GoPro,HERO8 Black
+GoPro,HERO9 Black
+GoPro,Hero3-Black Edition
+GoPro,Hero3-Silver Edition
+GoPro,GoPro Max
+GoPro,YHDC5170
+Google,Glass 1
+google,Nexus S
+Google,Pixel
+Google,Pixel 10
+Google,Pixel 10 Pro XL
+Google,Pixel 2
+Google,Pixel 2 XL
+Google,Pixel 3
+Google,Pixel 3 XL
+Google,Pixel 3a
+Google,Pixel 3a XL
+Google,Pixel 4
+Google,Pixel 4 XL
+Google,Pixel 4a
+Google,Pixel 5
+Google,Pixel 5a
+Google,Pixel 6a
+Google,Pixel 7 Pro
+Google,Pixel 7a
+Google,Pixel 8
+Google,Pixel 8 Pro
+Google,Pixel 8a
+Google,Pixel 9
+Google,Pixel 9 Pro
+Google,Pixel 9 Pro Fold
+Google,Pixel XL
+GrandTech GmbH,JD 5.0Z3 C
+GrandTech GmbH,JD 6.0Z3 C
+GrandTech GmbH,JD 8.0Z3 CL
+HMD Global,Nokia 8.3 5G
+HMD Global,Nokia 9
+hp photosmart 120,
+Hewlett-Packard,hp 635 Digital Camera
+HP,DeskJet F300
+HP,DeskJet F4100
+HP,DeskJet F4200
+HP,Officejet 4620
+Hewlett-Packard,HP PhotoSmart 210
+Hewlett-Packard,HP PhotoSmart 215
+Hewlett-Packard Company,HP PhotoSmart 315
+Hewlett-Packard,HP PhotoSmart 318
+Hewlett-Packard Company,hp PhotoSmart 320
+Hewlett-Packard,hp PhotoSmart 43x series
+Hewlett-Packard,hp photosmart 612
+Hewlett-Packard,HP PhotoSmart 618 (V1.10)
+Hewlett-Packard Company,hp PhotoSmart 620
+Hewlett-Packard Company,HP PhotoSmart 715
+Hewlett-Packard,hp photosmart 720
+Hewlett-Packard,hp photosmart 733
+Hewlett-Packard,hp photosmart 735
+Hewlett-Packard Company,HP PhotoSmart C20 Camera
+Hewlett-Packard Company,PhotoSmart C200
+Hewlett-Packard Company,PhotoSmart C30 Camera
+HP,PhotoSmart C3100
+Hewlett Packard,HP PhotoSmart C500 (V01.00)
+Hewlett-Packard,HP PhotoSmart C812 (V08.28)
+Hewlett-Packard,HP PhotoSmart C850 (V05.26)
+Hewlett-Packard,HP PhotoSmart C850 (V05.27)
+Hewlett-Packard,HP PhotoSmart C912 (V01.00)
+Hewlett-Packard,HP PhotoSmart C935 (V03.46)
+Hewlett-Packard,HP PhotoSmart C935 (V03.60)
+Hewlett-Packard,HP PhotoSmart C945 (V01.47)
+Hewlett-Packard,HP PhotoSmart C945 (V01.54)
+Hewlett-Packard,HP Photosmart E217
+Hewlett-Packard,HP Photosmart E317
+Hewlett-Packard,HP Photosmart E327
+Hewlett-Packard,HP Photosmart E330
+Hewlett-Packard,HP Photosmart E427
+Hewlett-Packard,SFAgUGhvdG9zbWFydCBNMjIgKFYwMS4wMCkgKz9VVT8B
+Hewlett-Packard,SFAgUGhvdG9zbWFydCBNMjMgKFYwMS4wMCkgZC0/zbgB
+Hewlett-Packard,Photosmart M305
+Hewlett-Packard,Photosmart M307
+Hewlett-Packard,Photosmart M407
+Hewlett-Packard,Photosmart M415
+Hewlett-Packard,Photosmart M417
+Hewlett-Packard,Photosmart M425
+Hewlett-Packard,HP Photosmart M437
+Hewlett-Packard,HP Photosmart M440
+Hewlett-Packard,Photosmart M517
+Hewlett-Packard,Photosmart M525
+Hewlett-Packard,Photosmart M527
+Hewlett-Packard,HP Photosmart M537
+Hewlett-Packard,HP Photosmart M540
+Hewlett-Packard,Photosmart M627
+Hewlett-Packard,HP Photosmart M630
+Hewlett-Packard,HP Photosmart M730
+Hewlett-Packard,HP Photosmart Mz60
+Hewlett-Packard,HP PhotoSmart R507 (V01.00)
+Hewlett-Packard,HP PhotoSmart R607 (V01.00)
+Hewlett-Packard,HP PhotoSmart R707 (V01.00)
+Hewlett-Packard,HP PhotoSmart R717 (V01.00)
+Hewlett-Packard,HP PhotoSmart R725  (V01.00)d
+Hewlett-Packard,HP PhotoSmart R727  (V01.00)
+Hewlett-Packard,HP Photosmart R740
+Hewlett-Packard,HP PhotoSmart R817  (V01.00)
+Hewlett-Packard,HP PhotoSmart R818  (V01.00)
+Hewlett-Packard,HP Photosmart R827  (V01.00)
+Hewlett-Packard,HP Photosmart R837
+Hewlett-Packard,HP Photosmart R840
+Hewlett-Packard,HP PhotoSmart R927  (V01.00)
+Hewlett-Packard,HP Photosmart R930
+Hewlett-Packard,HP Photosmart R960  (V01.00)
+Hewlett-Packard,HP Photosmart R960  (V01.00)+
+Hewlett-Packard,Photosmart M307
+HP,HP ScanJet 2400
+HP,HP ScanJet 3500
+HP,HP ScanJet 3670
+HP,HP ScanJet 3770
+HP,HP Scanjet 3800
+HP,HP ScanJet 3970
+HP,HP ScanJet 4070
+HP,HP Scanjet 4370
+HP,HP ScanJet 4500
+HP,HP Scanjet 4570
+HP,HP ScanJet 4570c
+HP,HP ScanJet 4600
+HP,HP Scanjet 4800
+HP,HP ScanJet 5530
+HP,HP ScanJet 5590
+HP,HP Scanjet 7650
+HP,HP ScanJet 8200
+HP,HP Scanjet 8300
+HP,HP Scanjet G2710
+HP,HP Scanjet G3010
+HP,HP Scanjet G4010
+HP,HP Scanjet G4050
+HP,HP Scanjet djf2100
+HP,HP Scanjet djf2200
+HP,HP Scanjet djf300
+HP,HP Scanjet djf4100
+HP,HP Scanjet djf4200
+HP,HP Scanjet e709a
+HP,HP Scanjet pls1017
+HP,HP Scanjet pls1312
+HP,HP ScanJet pls2800
+HP,HP ScanJet pls3015
+HP,HP ScanJet pls3020
+HP,HP ScanJet pls3050
+HP,HP ScanJet pls3052
+HP,HP ScanJet pls3390
+Hewlett-Packard Co.,iPAQ Voice Messenger
+,HP iPAQ hw6515
+HP,iPAQ rx3000
+HP,HP oj4100
+HP,HP oj4300
+HP,HP oj5500
+HP,HP oj5600
+HP,HP oj6200
+HP,HP oj6300
+HP,HP oj7200
+HP,HP oj7300
+HP,HP oj7400
+HP,HP oj_g510n
+HP,HP ojj4680
+HP,HP ojj6400
+HP,HP ojp7400
+HP,HP ojp7500
+HP,HP ojp7600
+HP,HP ojp7700
+HP,HP psc1100
+HP,HP psc1300
+HP,HP psc1310
+HP,HP psc1400
+HP,HP psc1500
+HP,HP psc1600
+HP,HP psc2100
+HP,HP psc2200
+HP,HP psc2300
+HP,HP psc2350
+HP,HP pst2570
+HP,HP pst2600
+HP,HP pst2700
+HP,HP pstc3100
+HP,HP pstc4100
+HP,HP pstc4200
+HP,HP pstc4340
+HP,HP pstc4400
+HP,HP pstc5100
+HP,HP pstc5200
+HP,HP pstc6200
+HTC,HTC 10
+HTC,7 Mozart
+HTC,7 Pro T7576
+HTC,7 Trophy
+HTC-8900,HTC-8900
+HTC,ADR6300
+HTC,ADR6350
+HTC,ADR6400L
+HTC,Apache
+HTC,Artemis
+HTC,Breeze
+HTC,HTC Butterfly
+HTC,HTC Butterfly 2
+HTC,HTC Butterfly S
+HTC,DL DesireZ v3.4 final
+HTC,HTC Desire
+HTC,HTC Desire 500
+HTC,HTC Desire 510
+HTC,HTC Desire 610
+HTC,HTC Desire 626s
+HTC,HTC Desire 816
+HTC,HTC Desire 820
+HTC,HTC Desire EYE
+HTC,Desire HD
+HTC,HTC Desire S
+HTC,HTC Desire X
+HTC,EVO
+HTC,Elf100
+HTC,Eris
+HTC,Excalibur
+HTC,HTC Gratia A6380
+HTC,HTC HD T8282
+HTC,HTC HD2
+HTC,HTC HD2 T8585
+HTC,HD7
+HTC,HERO200
+HTC,Hermes
+HTC,HTC Hero
+HTC,Kaiser
+HTC,LIBR100
+HTC,HTC Legend
+HTC,HTC MAX 4G
+HTC,MDA Vario III
+HTC,HTC Magic
+HTC,Nexus One
+HTC,HTC One
+HTC,HTC One M8s
+HTC,HTC One M9
+HTC,HTC One S
+HTC,HTC One X+
+HTC,HTC One max
+HTC,HTC One mini
+HTC,HTC One mini 2
+HTC,HTC One_M8
+HTC,Oxygen
+HTC,P3050
+HTC,HTC_P3300
+HTC,HTC_P3350
+HTC,HTC_P3400
+HTC,HTC_P3400i
+HTC,HTC_P3450
+HTC,HTC_P3451
+HTC,HTC_P3452
+HTC,HTC_P3470
+HTC,HTC_P3600
+HTC,P3600i
+HTC,HTC_P3650
+HTC,HTC_P3702
+HTC,HTC-P4350
+HTC-P4600,HTC-P4600
+HTC,PC36100
+HTC,PG06100
+HTC,PG86100
+HTC,PM23300
+HTC,HTC-S620
+HTC,HTC-S621
+HTC,S640
+HTC,HTC_S710
+HTC,HTC_S730
+HTC,HTC S740
+HTC,STAR 100
+HTC,HTC Sensation 4G
+HTC,HTC Sensation Z710e
+HTC,HTC Snap S521
+HTC,HTC Status
+HTC,T-Mobile G1
+HTC,T-Mobile G2
+HTC,T-Mobile myTouch 3G
+HTC,T-Mobile myTouch 3G Slide
+HTC,TITA100
+HTC,HTC Tattoo
+HTC,HTC Touch 3G T3232
+HTC,HTC Touch Cruise T4242
+HT,HTC Touch Diamond P370
+HTC,HTC Touch Diamond P3700
+HTC,HTC Touch Diamond2 T5353
+HTC,Touch Dual
+HTC,HTC Touch Elf
+HTC,HTC Touch HD T8282
+HTC,HTC Touch Pro T7272
+HTC,HTC Touch Pro2 T7373
+HTC,HTC Touch Viva T2223
+HTC,HTC Touch2 T3333
+HTC,Trinity
+HTC,HTC_TyTN
+HTC,HTC_TyTN_II
+HTC,HTC U Play
+HTC,Universal
+HTC,VOGU100
+HTC,HTC Vision
+HTC,HTC Wildfire
+HTC,HTC Wildfire S A510e
+HTC,HTC_X7500
+HTC,HTC_X7510
+HTC,Xda Orbit
+HTC,myTouch 4G
+HTC,HTC6435LVW
+HTC,HTC Incredible S
+Hasselblad,CFV 100C/907X
+Hasselblad,CFV II 50C/907X
+Hasselblad,Hasselblad CFV-50c/500
+Hasselblad,Hasselblad H4D-60
+Hasselblad,HB4116
+HASSELBLAD,HV
+Hasselblad,L1D-20c
+Hasselblad,L2D-20c
+HASSELBLAD,Lunar
+HASSELBLAD,Stellar
+Hasselblad,Hasselblad X1D
+Hasselblad,X1D II 50C
+HITACHI,DZ-BX35A
+HITACHI,DZ-BX35E
+HITACHI,DZ-BX37E
+HITACHI,DZ-GX25M
+HITACHI,DZ-GX3100E
+HITACHI,DZ-GX3200E
+HITACHI,DZ-GX3300E
+HITACHI,DZ-GX5020A
+HITACHI,DZ-GX5060E
+HITACHI,DZ-HS303E
+HITACHI,DZ-MV200E
+HITACHI,DZ-MV270A
+HITACHI,DZ-MV350A
+HITACHI,DZ-MV350E
+HITACHI,DZ-MV380E
+HITACHI,DZ-MV550E
+HITACHI,DZ-MV580A
+HITACHI,DZ-MV580E
+HITACHI,DZ-MV730E
+HITACHI,DZ-MV750E
+HITACHI,DZ-MV780E
+HITACHI,HDC-1061E
+Hitachi Living Systems Ltd.,HDC-301 Slim
+"Hitachi Living Systems, Ltd.",HDC-303X
+"Hitachi Living Systems, Ltd.",HDC-30X
+HITACHI,HDC-761E
+HITACHI,HDC-763E
+HITACHI,HDC-856E
+HITACHI,HDC751E
+HITACHI,HDC756E
+HONOR,FNE-NX9
+HUAWEI,COL-L29
+HUAWEI,COR-L29
+HUAWEI,BKL-L09
+HUAWEI,BLA-A09
+HUAWEI,BLA-L29
+HUAWEI,BLN-L21
+HUAWEI,BND-L21
+HUAWEI,CLT-L09
+HUAWEI,CLT-L29
+HUAWEI,HUAWEI CRR-L09
+HUAWEI,ELS-NX9
+HUAWEI,EML-L09
+HUAWEI,EVA-L09
+HUAWEI,HUAWEI GRA-L09
+HUAWEI,IDEOS X5
+HUAWEI,Ideos
+HUAWEI,Ideos S7
+HUAWEI,LLD-L31
+HUAWEI,LYA-L29
+HUAWEI,MAR-LX1A
+HUAWEI,PCT-L29
+HUAWEI,POT-LX1
+HUAWEI,HUAWEI SCL-L04
+HUAWEI,STF-L09
+HUAWEI,STK-LX1
+HUAWEI,TRT-LX1
+HUAWEI,VKY-L09
+HUAWEI,VOG-L29
+HUAWEI,Vodafone 845
+HUAWEI,YAL-L21
+HUAWEI,pulse
+IDAN,FC220
+Impak Film Sanner,F-12 Plus
+Infisense,P2_USB_IR
+Insta360,Insta360 ONE X
+Insta360,OneAndroid.Panorama.Photo
+Insta360,Insta360 Pro
+Insta360,Insta360 Pro2
+JENIMAGE,JD C 3.1 z3
+JENIMAGE,JD5.2z3
+JENOPTIFIED,JD4.1Z8
+"JK Imaging, Ltd.",KODAK PIXPRO AZ901
+"JK Imaging, Ltd.",KODAK PIXPRO FZ152
+"JK Imaging, Ltd.",KODAK PIXPRO FZ201
+"JK Imaging, Ltd.",KODAK PIXPRO S-1
+"JK Imaging, Ltd.",KODAK PIXPRO SL10
+"JK Imaging, Ltd.",KODAK PIXPRO SP360
+"JK Imaging, Ltd.",PIXPRO 4KVR360
+JVC,GC-A70
+JVC,GC-FM1
+JVC,GC-FM2
+JVC,GC-PX10
+JVC,GC-QX3
+JVC,GC-QX5
+JVC,GC-S5
+JVC,GC-X1E
+JVC,GC-X3E
+JVC,GR-D200
+JVC,GR-D201
+JVC,GR-D230
+JVC,GR-D231
+JVC,GR-D270
+JVC,GR-D290
+JVC,GR-D295
+JVC,GR-D360
+JVC,GR-D370
+JVC,GR-D390
+JVC,GR-D396
+JVC,GR-D60
+JVC,GR-D640
+JVC,GR-D645
+JVC,GR-D650
+JVC,GR-D70
+JVC,GR-D71
+JVC,GR-D72
+JVC,GR-D73
+JVC,GR-D74
+JVC,GR-D760
+JVC,GR-D770
+JVC,GR-D790
+JVC,GR-D860
+JVC,GR-D870
+JVC,GR-D90
+JVC,GR-D91
+JVC,GR-D93
+JVC,GR-D94
+JVC,GR-DF460
+JVC,GR-DF470
+JVC,GR-DF540
+JVC,GR-DF550
+JVC,GR-DF570
+JVC,GR-DV***
+JVC,GR-DV1800
+JVC,GR-DV2000
+JVC,GR-DV3000
+JVC,GR-DV4000
+JVC,GR-DV500
+JVC,GR-DV5000
+JVC,GR-DV700
+JVC,GR-DV800
+JVC,GR-DV900
+JVC,GR-DVL1020
+JVC,GR-DVL1170
+JVC,GR-DVL365
+JVC,GR-DVL367
+JVC,GR-DVL520
+JVC,GR-DVL522
+JVC,GR-DVL525
+JVC,GR-DVL700
+JVC,GR-DVL720
+JVC,GR-DVL722
+JVC,GR-DVL725
+JVC,GR-DVL765
+JVC,GR-DVL767
+JVC,GR-DVL820
+JVC,GR-DVL828
+JVC,GR-DVL920
+JVC,GR-DVL925
+JVC,GR-DVL970
+JVC,GR-DVL9700
+JVC,GR-DVL9800
+JVC,GR-DVM75
+JVC,GR-DVM76
+JVC,GR-DVM90
+JVC,GR-DVM96
+JVC,GR-DVP1
+JVC,GR-DVP3
+JVC,GR-DVP5
+JVC,GR-DVP7
+JVC,GR-DVP9
+JVC,GR-DVX507
+JVC,GR-DVX509
+JVC,GR-DVX707
+JVC,GR-DVX709
+JVC,GR-DVX77
+JVC,GR-DVX78
+JVC,GR-DVX88
+JVC,GR-DVX9
+JVC,GR-DVX9*
+JVC,GR-DX100
+JVC,GR-DX107
+JVC,GR-DX300
+JVC,GR-DX307
+JVC,GR-DX317
+JVC,GR-DX67
+JVC,GR-DX75
+JVC,GR-DX76
+JVC,GR-DX77
+JVC,GR-DX95
+JVC,GR-DX97
+JVC,GR-DZ7
+JVC,GR-X5
+JVC,GZ-HD10
+JVC,GZ-HD30
+JVC,GZ-HD300
+JVC,GZ-HD40
+JVC,GZ-HD5
+JVC,GZ-HD6
+JVC,GZ-HM1
+JVC,GZ-HM200
+JVC,GZ-HM300
+JVC,GZ-HM320
+JVC,GZ-HM335
+JVC,GZ-HM446
+JVC,GZ-HM550
+JVC,GZ-MC100
+JVC,GZ-MC200
+JVC,GZ-MC500
+JVC,GZ-MG130
+JVC,GZ-MG133
+JVC,GZ-MG134
+JVC,GZ-MG135
+JVC,GZ-MG140
+JVC,GZ-MG145
+JVC,GZ-MG150
+JVC,GZ-MG155
+JVC,GZ-MG177
+JVC,GZ-MG20
+JVC,GZ-MG21
+JVC,GZ-MG22
+JVC,GZ-MG255
+JVC,GZ-MG26
+JVC,GZ-MG27
+JVC,GZ-MG275
+JVC,GZ-MG30
+JVC,GZ-MG33
+JVC,GZ-MG330
+JVC,GZ-MG331
+JVC,GZ-MG333
+JVC,GZ-MG334
+JVC,GZ-MG335
+JVC,GZ-MG340
+JVC,GZ-MG344
+JVC,GZ-MG36
+JVC,GZ-MG360
+JVC,GZ-MG364
+JVC,GZ-MG365
+JVC,GZ-MG37
+JVC,GZ-MG40
+JVC,GZ-MG430
+JVC,GZ-MG435
+JVC,GZ-MG465
+JVC,GZ-MG47
+JVC,GZ-MG50
+JVC,GZ-MG505
+JVC,GZ-MG530
+JVC,GZ-MG555
+JVC,GZ-MG57
+JVC,GZ-MG575
+JVC,GZ-MG60
+JVC,GZ-MG610
+JVC,GZ-MG620
+JVC,GZ-MG630
+JVC,GZ-MG645
+JVC,GZ-MG67
+JVC,GZ-MG670
+JVC,GZ-MG680
+JVC,GZ-MG70
+JVC,GZ-MG730
+JVC,GZ-MG750
+JVC,GZ-MG77
+JVC,GZ-MG840
+JVC,GZ-MS100
+JVC,GZ-MS120
+JVC,GZ-MS130
+JVC,GZ-MS215
+JVC,GZ-MS230
+JVC,GZ-MS90
+JVC,GZ-MS95
+JVC,GZ-X900
+JVC,GZ_HD3
+JVC,GZ_HD7
+Jenimage Europe GmbH,Jenoptik JD 6.0 z3 MPEG4
+JENOPTIK,JD 2100f
+JENOPTIK,JD 3.3x4ie
+"JENOPTIK OPTICAL CO,LTD",JD2100Z3S
+"JENOPTIK OPTICAL CO,LTD",JD3300
+JENOPTIK,JD4.0LCD
+"JENOPTIK OPTICAL CO,LTD",JD4100
+"JENOPTIK OPTICAL CO,LTD",JD4100Z3S
+"JENOPTIK OPTICAL CO,LTD",JD5200
+"JENOPTIK OPTICAL CO,LTD",JD5200Z
+KDDI-CA,A3012CA
+KDDI-CA,A5302CA
+KDDI-CA,A5401CA
+KDDI-CA,A5403CA
+KDDI-CA,A5406CA
+KDDI-CA,A5407CA
+KDDI-CA,A5512CA
+KDDI-CA,W21CA
+KDDI-CA,W31CA
+KDDI-CA,W41CA
+KDDI-CA,W42CA
+KDDI-CA,W43CA
+KDDI-CA,W51CA
+KDDI-CA,W52CA
+KDDI-CA,W53CA
+KDDI-CA,W61CA
+KDDI-AA,QCAM40a
+KDDI-HI,A5303H
+KDDI-HI,A5303H2
+KDDI-HI,W11H
+KDDI-HI,W21H
+KDDI-HI,W22H
+KDDI-HI,W31H
+KDDI-HI,W43H
+KDDI-KC,A1013K
+KDDI-KC,A1401K
+KDDI-KC,A1403K
+KDDI-KC,A5305K
+KDDI-KC,A5502K
+KDDI-KC,W11K
+KDDI-KC,W21K
+KDDI-KC,W31K
+KDDI-KC,W42K
+KDDI-KC,W52K
+KDDI-MA,W51P
+KDDI-SA,A1302SA
+KDDI-SA,A1303SA
+KDDI-SA,A1305SA
+KDDI-SA,A3015SA
+KDDI-SA,A5503SA
+KDDI-SA,A5505SA
+KDDI-SA,A5527SA
+KDDI-SA,W21SA
+KDDI-SA,W22SA
+KDDI-SA,W31SA
+KDDI-SA,W32SA
+KDDI-SA,W33SA
+KDDI-SA,W41SA
+KDDI-SA,W51SA
+KDDI-SA,W52SA
+KDDI-SA,W64SA
+KDDI-SE,A1301S
+KDDI-SE,A5402S
+KDDI-SH,W52SH
+KDDI-SN,A1402S
+KDDI-SN,A1402S2
+KDDI-SN,A1404S
+KDDI-SN,A5404S
+KDDI-SN,W21S
+KDDI-SN,W31S
+KDDI-SN,W42S
+KDDI-SN,W43S
+KDDI-SN,W44S
+KDDI-SN,W51S
+KDDI-SN,W52S
+KDDI-SN,W53S
+KDDI-ST,A5306ST
+KDDI-ST,A5405SA
+KDDI-ST,A5507SA
+KDDI-ST,INFOBAR
+KDDI-ST,talby
+KDDI-TS,A1304T
+KDDI-TS,A5301T
+KDDI-TS,A5304T
+KDDI-TS,A5501T
+KDDI-TS,A5504T
+KDDI-TS,A5506T
+KDDI-TS,A5509T
+KDDI-TS,W21T
+KDDI-TS,W31T
+KDDI-TS,W42T
+KDDI-TS,W44T
+KDDI-TS,W47T
+KDDI-TS,W52T
+KDDI-TS,W53T
+KDDI-TS,W54T
+KDDI-TS,W55T
+Samsung Techwin,<KENOX S1050  / Samsung S1050>
+Samsung Techwin,<KENOX S630  / Samsung S630>
+Samsung Techwin,<KENOX S730  / Samsung S730>
+Samsung Techwin,<KENOX S760  / Samsung S760>
+Samsung Techwin,<KENOX S860  / Samsung S860>
+KU580,LG Innotek
+KYE Systems Corp.,G-Shot A435
+KYE Systems Corp.,G-Shot G512
+Kodak,
+Kodak,
+Eastman Kodak Company,Kodak 1640 Film Scanner
+Kodak,Kodak 660
+EASTMAN KODAK COMPANY,KODAK C310 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK C330 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK C340 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK C360 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK C663 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK C875 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CD33 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CD43 ZOOM DIGITAL CAMERA
+Eastman Kodak Company,Kodak CLAS Digital Film Scanner / HR200
+Eastman Kodak Company,KODAK CLAS DIGITAL FILM SCANNER / HR200
+EASTMAN KODAK COMPANY,KODAK CX4200 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX4210 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX4300 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX4310 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX6330 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX6445 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX7330 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX7430 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX7430 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX7525 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK CX7530 ZOOM DIGITAL CAMERA
+Eastman Kodak Company,DC200      (V02.10)
+Eastman Kodak Company,DC210 Zoom (V05.00)
+EASTMAN KODAK COMPANY,KODAK DC240 ZOOM DIGITAL CAMERA
+Eastman Kodak Company,KODAK DC265 ZOOM DIGITAL CAMERA (V01.00)
+EASTMAN KODAK COMPANY,KODAK DC280 ZOOM DIGITAL CAMERA
+Eastman Kodak Company,KODAK DC290 Zoom Digital Camera (V01.00)
+EASTMAN KODAK COMPANY,KODAK DC3200 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DC3400 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DC3800 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DC4800 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DC5000 ZOOM DIGITAL CAMERA
+Kodak,DCS Pro 14N
+Kodak,DCS Pro 14nx
+Kodak,Kodak DCS Pro SLR/c
+Kodak,DCS Pro SLR/n
+Kodak,Kodak DCS520C
+Kodak,Kodak DCS760C
+EASTMAN KODAK COMPANY,KODAK DX3500 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX3600 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX3900 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX3900 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX4330 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX4530 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX4900 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX4900 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX6340 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX6440 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX6490 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX6490 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX7440 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX7590 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX7630 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK DX7630 ZOOM DIGITAL CAMERA
+Eastman Kodak Company,KODAK DIGITAL SCIENCE DC220 (V01.00)
+Eastman Kodak Company,KODAK DIGITAL SCIENCE DC260 (V01.00)
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C1013 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C140 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C143 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C180 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C182 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C190 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C300 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C315 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C433 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C513 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C533 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C613 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C633 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C643 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C653 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C713 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C743 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C753 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C763 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C813 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE C913 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE CX4230 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE CX6200 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE CX6230 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE CX7220 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE CX7300 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE CX7310 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE DX3215 Zoom Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE DX3700 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M1033 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M1063 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M1073 IS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M1093 IS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M320 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M340 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M341 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M380 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M381 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M530 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M550 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M575 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M580 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M590 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M753 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M763 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M853 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M863 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M873 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M883 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE M893 IS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,"KODAK EASYSHARE Mini Camera, M200"
+EASTMAN KODAK COMPANY,"KODAK EASYSHARE Sport Camera, C123"
+EASTMAN KODAK COMPANY,"KODAK EASYSHARE Touch Camera, M5370"
+EASTMAN KODAK COMPANY,KODAK EASYSHARE V1003 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE V1073 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE V1273 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE V803 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,"KODAK EASYSHARE Wireless Camera, M750"
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z1012 IS Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z1015 IS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z1085 IS ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z1485 IS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EasyShare Z5010 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z710 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z8612 IS Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z915 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EASYSHARE Z950 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK EasyShare Z980 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EasyShare Z981 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EasyShare Z990 Digital Camera
+EASTMAN KODAK COMPANY,KODAK EASYSHARE ZD710 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,Kodak EasyShare-One (S143)
+EASTMAN KODAK COMPANY,KODAK LS420 DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK LS443 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK LS443 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK LS633 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK LS743 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK LS753 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK LS755 ZOOM DIGITAL CAMERA
+Eastman Kodak,"KODAK Mini Video Camera, Zm1"
+EASTMAN KODAK COMPANY,KODAK P712 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK P850 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK P880 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK P880 ZOOM DIGITAL CAMERA
+Eastman Kodak Company,Kodak PCD Film Scanner 6000
+EASTMAN KODAK COMPANY,KODAK PalmPix CAMERA V1.2.0000
+Eastman Kodak Company,Picture Kiosk G4
+Eastman Kodak Company,Picture Maker G3
+EASTMAN KODAK COMPANY,PIXPRO AZ251
+EASTMAN KODAK COMPANY,PIXPRO AZ361
+EASTMAN KODAK COMPANY,PIXPRO AZ362
+EASTMAN KODAK COMPANY,PIXPRO AZ521
+EASTMAN KODAK COMPANY,"KODAK PLAYSPORT Video Camera, Zx5"
+EASTMAN KODAK COMPANY,"KODAK PLAYFULL Video Camera, Ze1"
+EASTMAN KODAK COMPANY,"KODAK PLAYFULL Waterproof Video Camera, Model Ze2"
+Kodak,ProBack
+Eastman Kodak Company,Kodak RFS 3600 Film Scanner
+EASTMAN KODAK COMPANY,"KODAK Slice Touchscreen Camera, R502"
+EASTMAN KODAK COMPANY,KODAK V1233 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK V1253 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK V530 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK V550 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK V570 DUAL LENS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK V603 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK V610 DUAL LENS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK V705 DUAL LENS DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z1275 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z1285 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z612 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z612 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z650 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z700 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z712 IS ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z730 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z740 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z7590 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z760 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z812 IS ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Z885 ZOOM DIGITAL CAMERA
+EASTMAN KODAK COMPANY,KODAK Zi6 Pocket Video Camera
+EASTMAN KODAK COMPANY,KODAK Zi8 Pocket Video Camera
+EASTMAN KODAK COMPANY,KODAK Zx1 Pocket Video Camera
+Eastman Kodak Company,Kodak mc3
+KONICA CORPORATION,Konica Digital Camera DG-1
+Konica Corporation,Konica Digital Camera DG-2
+Konica Corporation,Konica Digital Camera KD-200Z
+Konica Corporation,Konica Digital Camera KD-210Z
+Konica Corporation,Konica Digital Camera KD-310Z
+Konica Corporation,Konica Digital Camera KD-400Z
+Konica,Konica Digital Camera KD-410Z
+Konica Corporation,Konica Digital Camera KD-500Z
+Konica,Konica Digital Camera KD-510Z
+KONICA CORPORATION,Konica Digital Camera Q-M100
+KONICA CORPORATION,Konica Digital Camera Q-M100V
+KONICA CORPORATION,Konica Digital Camera Q-M200
+KONICA,Digital Revio KD-100
+KONICA,KONICA KD-2
+KONICA,KONICA KD-20
+KONICA,KONICA KD-20M
+Konica,KD-220Z
+KONICA,KONICA KD-25
+KONICA,KD-300Z
+KONICA,KONICA KD-30M
+KONICA,KD-3100
+KONICA,KD-3300
+"Konica Co., Ltd.",KONICA KDC1310
+KONICA MINOLTA,ALPHA SWEET DIGITAL
+KONICA MINOLTA,ALPHA-7 DIGITAL
+KONICA MINOLTA,DG-5W
+KONICA MINOLTA,DYNAX 5D
+KONICA MINOLTA,DYNAX 7D
+"Konica Minolta Camera, Inc.",DiMAGE A2
+KONICA MINOLTA,DiMAGE A200
+KONICA MINOLTA,DiMAGE E40
+KONICA MINOLTA,DiMAGE E50
+KONICA MINOLTA,DiMAGE E500
+"KONICA MINOLTA CAMERA, Inc.",DiMAGE G400
+KONICA MINOLTA,DiMAGE G530
+"Konica Minolta Photo Imaging, Inc.",DiMAGE G600
+KONICA MINOLTA,DiMAGE X1
+"Konica Minolta Camera, Inc.",DiMAGE X21
+KONICA MINOLTA,DiMAGE X31
+KONICA MINOLTA,DiMAGE X50
+KONICA MINOLTA,DiMAGE X60
+"Konica Minolta Camera, Inc.",DiMAGE Xg
+KONICA MINOLTA,DiMAGE Z10
+"Konica Minolta Camera, Inc.",DiMAGE Z2
+KONICA MINOLTA,DiMAGE Z20
+KONICA MINOLTA,DiMAGE Z3
+KONICA MINOLTA,DiMAGE Z5
+KONICA MINOLTA,DiMAGE Z6
+KONICA MINOLTA,MAXXUM 5D
+KONICA MINOLTA,MAXXUM 7D
+"KONICA MINOLTA CAMERA, Inc.",Revio KD-420Z
+Konica,Revio C2
+Konica,e-miniD
+KYOCERA,EZ 1.3
+KYOCERA,FC-3300
+KYOCERA,FC-S3
+KYOCERA,FC-S3x
+KYOCERA,FC-S4
+KYOCERA,Finecam M400R
+KYOCERA,Finecam M410R
+KYOCERA,Finecam S3L
+KYOCERA,Finecam S3R
+KYOCERA,Finecam S5
+KYOCERA,Finecam S5R
+KYOCERA,Finecam SL300R
+KYOCERA,Finecam SL400R
+KYOCERA,Finecam-L3
+KYOCERA,Finecam-L30
+KYOCERA,Finecam-L3v
+KYOCERA,Finecam-L4
+KYOCERA,Finecam-L4v
+Kyocera,Hydro
+KYOCERA,SAMURAI 2100DG
+KYOCERA,CONTAX N DIGITAL
+KYOCERA,CONTAX SL300R T*
+KYOCERA,CONTAX Tvs Digital
+KYOCERA,CONTAX U4R
+KYOCERA,CONTAX i4R
+KYOCERA,WX310K
+LG Electronics,
+ LG Electronics Inc.,A310
+LG Electronics,LG-AX260
+LG Elec.,BL40
+LG ELECTRONICS,CU720
+LGE,CU915
+LG Electronics,LG-D331
+LG Electronics,LG-D415
+LG Electronics,LG-D680
+LG Electronics,LG-D800
+LG Electronics,LG-D802
+LG Electronics,LG-D838
+LG Electronics,LG-D855
+LG Electronics,LG-D950
+LG Electronics,LG-F400K
+LG Electronics Inc.,GB-220
+LG Electronics Inc.,GB-230
+LG Electronics Inc.,GB-250
+LGE,GB210
+LG Electronics,GC900
+LG Electronics Inc.,GD-330
+LG Electronics Inc.,GD-350
+LG Electronics,GD510
+LG Elec.,GD880
+LG Electronics,GD900
+LG Electronics Inc.,GM-310
+LG_Electronics,GM200
+LG Electronics,GM360
+LG electronics,GS155
+LG Electronics,GS200
+LG Electronics,GS205
+LG Electronics,GS290
+LG Electronics,GS500
+LGE,GS505
+LG Electronics,GT350
+LG Electronics,GT365
+LG Electronics,GT540
+LG Electronics Inc.,GU-230
+LG Electronics,GW520
+LG,GW550
+LG Electronics Inc.,GX-300
+LG Electronics,GX200
+LG Electronics,GX500
+LG Electronics,LG-H631
+LG Electronics,LG-H815
+LG Electronics,LG-H870
+LG Elec.,KB770
+LG Electronics Inc.,KC-560
+LG Electronics,KC550
+LG Electronics,KC780
+LG Electronics,KC910
+LG Electronics Inc.,KE500
+LG Electronics Inc.,KE590
+LG Electronics,KE850
+LG Electronics,KE990
+LG Electronics,KE998
+LG Electronics Inc.,KF-350
+LG_Electronics,KF240
+LG_Electronics,KF300
+LG Electronics,KF301
+LG Elec.,KF310
+LG Electronics,KF510
+LG Electronics,KF600
+LG Electronics,KF690
+LG Electronics,KF700
+LG Electronics,KF750
+LG Electronics,KF900
+LG Electronics Inc.,KG920
+LG CYON,KH-1200
+LG CYON,KH-3100
+LG CYON,KH1600
+LG CYON,KH1800
+LG Electronics,KH5200
+LG CYON,KH8000
+LG Mobile,KM330
+LG Electronics,KM380
+LG Mobile,LG-KM500
+LG Electronics,KM555
+LG Mobile,LG-KM710
+LG Electronics,KM900
+LG CYON,KP 3800
+LG CYON,KP 4000
+LG CYON,KP 4500
+LG ELEC,KP130
+LGE,KP199
+LG ELEC,KP202
+LG ELEC,KP230
+LG ELEC,KP235
+LG Mobile,KP293i
+LG Mobile,KP320
+LG Electronics,KP500
+LG Electronics,KP570
+LGE,KS20
+LG Electronics,KS360
+LG Electronics,KS660
+LG CYON,KU4000
+LG Electronics,KU990
+LG Electronics,KU990i
+LGE,KV4200
+LG CYON,LB-3100
+LG CYON,LG-LB1700
+LG CYON,LG-LB2800
+LG CYON,LC 3200
+LGE,LM-G710N
+LG CYON,LU2300
+LGE,LV4200
+LG Mobile,MG295d
+LGE,MG810
+LG Electronics,MX-8550
+LGE,Nexus 5
+LG Electronics,P520
+LG Electronics,RUMOR
+"LG Electronics, Inc.",LG RUMOR2
+"LG Electronics, Inc.",LG Rumour 2
+LG CYON,SB-210
+LG CYON,SB-310
+LG CYON,SC 330
+LG CYON,SD 910
+LG CYON,SH-130
+LG CYON,SH-150
+LG CYON,SH-210
+LG CYON,SU910
+LG CYON,SU950
+LGE,SV420
+LG Electronics,T300
+LG Electronics,T310
+LG Electronics,T320
+LG Elec.,U960
+LG Electronics,U990i
+LG Electronics,VX-8550
+LG Electronics,VX-8800
+LG Electronics,VX-9200
+LG Electronics,VX-9700
+LG Electronics,LG-VX8300
+LG Electronics,LG-VX8350
+"LG Electronics, Inc.",LG-VX8360
+LG Electronics Inc,LG-VX8560
+LG Electronics,LG-VX8600
+LG Electronics,LG-K428
+LG Electronics,LG8300
+LGE,Nexus 5X
+LG Electronics,LGM-V300S
+LG Electronics,LGMS323
+LEGEND,Lenovo V20C
+LEGEND,SOSHOW506
+LEGEND,SOSHOW730
+LEGEND,SoShow530
+LEGEND GROUP LIMITED,T30
+Legend,V20
+LEGEND,V30
+LEGEND,V30C
+LEGEND,V35
+LEGEND,V40
+legend DSC,soshow305
+LEICA,C (Typ 112)
+LEICA,C-LUX 1
+LEICA,C-LUX 2
+LEICA,C-LUX 3
+LEICA,CAM-DC25
+LEICA CAMERA AG,LEICA CL
+LEICA,D-LUX
+LEICA,D-LUX (Typ 109)
+LEICA,D-LUX 3
+LEICA,D-LUX 4
+LEICA,D-LUX 5
+LEICA,D-LUX 6
+LEICA,D-LUX2
+LEICA CAMERA AG,D-Lux 7
+LEICA CAMERA AG,LEICA D-Lux 8
+LEICA,DIGILUX 2
+LEICA,DIGILUX 3
+LEICA,Digilux1
+Leica Camera AG,LEICA M (Typ 240)
+Leica Camera AG,LEICA M (Typ 262)
+Leica Camera AG,LEICA M MONOCHROM (Typ 246)
+Leica Camera AG,M Monochrom
+Leica Camera AG,LEICA M10 MONOCHROM
+Leica Camera AG,LEICA M10-D
+Leica Camera AG,LEICA M10-P
+Leica Camera AG,LEICA M10-R
+Leica Camera AG,LEICA M11
+Leica Camera AG,LEICA M11 Monochrom
+Leica Camera AG,LEICA M11-P
+Leica Camera AG,M8 Digital Camera
+Leica Camera AG,M9 Digital Camera
+LEICA CAMERA AG,LEICA Q (Typ 116)
+LEICA CAMERA AG,LEICA Q2
+LEICA CAMERA AG,LEICA Q2 MONO
+LEICA CAMERA AG,LEICA Q3
+LEICA CAMERA AG,LEICA Q3 43
+Leica Camera AG,R8 - Digital Back DMR
+Leica Camera AG,R9 - Digital Back DMR
+Leica Camera AG,LEICA S (Typ 007)
+Leica Camera AG,S2
+LEICA CAMERA AG,LEICA SL (Typ 601)
+LEICA CAMERA AG,LEICA SL2
+LEICA CAMERA AG,LEICA SL2-S
+LEICA CAMERA AG,LEICA SL3
+LEICA CAMERA AG,LEICA T (Typ 701)
+LEICA CAMERA AG,LEICA TL
+LEICA CAMERA AG,LEICA TL2
+LEICA,V-LUX (Typ 114)
+LEICA,V-LUX 1
+LEICA,V-LUX 2
+LEICA,V-LUX 20
+LEICA,V-LUX 3
+LEICA,V-LUX 30
+LEICA,V-LUX 4
+LEICA,V-LUX 40
+LEICA CAMERA AG,V-Lux 5
+LEICA CAMERA AG,LEICA X (Typ 113)
+LEICA CAMERA AG,LEICA X VARIO (Typ 107)
+LEICA CAMERA AG,LEICA X-E (Typ 102)
+LEICA CAMERA AG,LEICA X-U (Typ 113)
+LEICA CAMERA AG,LEICA X1
+LEICA CAMERA AG,LEICA X2
+LEICA,digilux
+LEICA,digilux 4.3
+LEICA,digilux zoom
+Light,L16
+Logitech Inc.,ClickSmart
+Logitech Inc.,ClickSmart 820
+Logitech Inc.,Pocket Digital 130
+LUMICRON Technology Inc.,616z3 Digital Camera
+LUMICRON,LDC-4013
+LUMICRON,LDC-4028
+Lumicron,LDC-660S
+M6550B-SMAARZ-4.4.80,Samsung SCH-U700
+MSM6100,KC3500
+MSM6100,LC3600
+MSM6250,SGH-Z510
+MSM6500,MICRON_AU75C
+MSM6500,SCH-A303
+MSM6500,SCH-R610
+MSM6500,SPH-A720
+MSM6500,SPH-A900
+MSM6500,SPH-A920
+MSM6500,SPH-M500
+MSM6500,SPH-M510
+MSM6500,SPH-M620
+MSM6500,Unknown Sensor
+MSM6550,SPH-M610
+MSM6550,Samsung SCH-A990
+MUSTEK,DV5300SE
+MAGINON,PERFORMIC S5
+"MAGINON  OPTICAL CO,LTD",SX330Z
+"Mamiya-OP Co.,Ltd.",MAMIYA ZD
+MEDION AG,
+Medion,636Z3
+MEDION,MD 85173
+Medion,MD 85375
+Medion,MD 85447
+MEDION 5MP DIGITCAM,MD 85675
+MEDION,MD 85830
+MEDION,MD 86066
+"  MEDION OPTICAL CO,LTD",MD210Z3
+"  MEDION OPTICAL CO,LTD",MD410Z3
+"  MEDION OPTICAL CO,LTD",MD411Z3
+"  MEDION OPTICAL CO,LTD",MD511Z3
+MEDION,MD5.2z3
+Medion AG,MD85863
+Medion AG,MD86063
+Medion AG,MD86276
+"Medion   OPTICAL CO,LTD",MD9653
+"Medion   OPTICAL CO,LTD",MD9700
+"Medion   OPTICAL CO,LTD",SX410Z
+?,Mega-Image III
+Mercury Peripherals Inc.,CyberPix E-350V
+Mercury Peripherals Inc.,CyberPix E-450V
+Mercury Peripherals Inc.,CyberPix E-550V
+Mercury Peripherals Inc.,CyberPix S-450V
+Mercury Peripherals Inc.,CyberPix S-550V
+Mercury Peripherals Inc.,Deluxe Classic Cam
+Microsoft,Lumia 435
+Microsoft,Lumia 530
+Microsoft,Lumia 532
+Microsoft,Lumia 532 Dual SIM
+Microsoft,Lumia 535
+Microsoft,Lumia 535 Dual SIM
+Microsoft,Lumia 540 Dual SIM
+Microsoft,Lumia 640 Dual SIM
+Microsoft,Lumia 640 LTE
+Microsoft,Lumia 640 LTE Dual SIM
+Microsoft,Lumia 640 XL
+Microsoft,Lumia 640 XL LTE
+Microsoft,Lumia 640 XL LTE Dual SIM
+Microsoft,Lumia 930
+Microsoft,Lumia 950 XL
+Microsoft Mobile,Nokia_X2
+Minolta Co. Ltd.,Dimage 2300
+"Minolta Co., Ltd",Dimage 2330 Zoom
+"Minolta Co., Ltd.",DiMAGE 5
+"Minolta Co., Ltd.",DiMAGE 7
+"Minolta Co., Ltd.",DiMAGE 7Hi
+"Minolta Co., Ltd.",DiMAGE 7i
+"Minolta Co., Ltd.",DiMAGE A1
+"Minolta Co., Ltd.",DiMAGE E201
+"Minolta Co.,Ltd.",DiMAGE E203
+"Minolta Co., Ltd.",DiMAGE E223
+"minolta Co., Ltd.",DiMAGE E323
+"Minolta Co., Ltd.",Dimage EX
+"Minolta Co., Ltd.",DiMAGE F100
+"Minolta Co., Ltd.",DiMAGE F200
+"Minolta Co., Ltd.",DiMAGE F300
+"Minolta Co., Ltd.",DiMAGE G500
+"Minolta Co.,Ltd.",Dimage RD 3000
+"Minolta Co., Ltd.",DiMAGE S304
+"Minolta Co., Ltd.",DiMAGE S404
+"Minolta Co., Ltd.",DiMAGE S414
+MINOLTA,Dimage V
+"MINOLTA CO.,LTD",DiMAGE X
+"Minolta Co., Ltd.",DiMAGE X20
+"Minolta Co., Ltd.",DiMAGE Xi
+"Minolta Co., Ltd.",DiMAGE Xt
+"Minolta Co., Ltd.",DiMAGE Z1
+"Minolta Co.,Ltd.",RD-175
+MOTO,1.2 MP
+Motorola,A1600
+Motorol,A780
+Motorola,C261
+Motorola,DROID2 4efa0021ffd800000a3a513a13025025
+Motorola,DROID2 GLOBAL 2f140001ffd800000a3a9c5303026017
+motorola,DROID3
+Motorola,DROID BIONIC
+Motorola,DROID RAZR
+Motorola,DROID RAZR HD
+Motorola,DROIDX 76120001ffd800000a3a973017032014
+Motorola,DROID X2
+MOTOROLA,E1070
+Motorola,E365
+MOTOROLA,E770
+MOTOROLA,E770v
+Motorola,EX300
+Motorola,EZX Camera
+Motorola,Moto G (4)
+MOTOROLA,K3
+Motorola,MB200
+Motorola,MB300
+Motorola,MB860
+Motorola Korea Inc,MS550
+Motorola Korea Inc,MS600
+Motorola Korea Inc,MS700
+Motorola Korea Inc,MS800
+Motorola C.320.01.07.31.07,Megapixel
+Motorola,Milestone
+Motorola,MilestoneXT720
+motorola,Nexus 6
+MOTOROLA,RAZR i
+MOTOROLA,RAZRV3x
+MOTOROLA,RAZRV3xM
+MOTOROLA,RAZRV3xR
+MOTOROLA,RAZRV3xv
+MOTOROLA,RAZRV3xx
+MOTOROLA,RAZRV6
+MOTOROLA,RAZRV6v
+MOTOROLA,RAZRV6vc
+MOTOROLA,V1075
+MOTOROLA,V1100
+MOTOROLA,V3
+Motorola,V300
+Motorola,XT1032
+Motorola,XT1039
+Motorola,XT1052
+Motorola,XT1060
+Motorola,XT1068
+Motorola,XT1080
+motorola,XT1254
+Motorola,XT1562
+Motorola,XT1572
+Motorola,XT1575
+Motorola,XT1580
+Motorola,XT1585
+motorola,XT1635-02
+Motorola,XT720
+Motorola,XT890
+Motorola,XT907
+Motorola Mobility,Xoom
+motorola,moto e
+motorola,moto g stylus 5G
+motorola,moto g(40) fusion
+Motorola,MotoG3
+MOTOROLA,MOTORAZRV9
+Motorola Korea Inc,MOTOROLA - V9m
+Motorola,Motorola Evoke QA4
+Motorola,Moto Q 9c
+Motorola,Motorola V600 cellphone
+Motorola,Motorola VE66 555554ba170d0d090909090909090909
+motorola,motorola edge 50 neo
+MOULTRIE,A-5
+MOULTRIE,D-555i
+MOULTRIE,M-880c
+MOULTRIE,M-990n
+MOULTRIE,M100
+MOULTRIE,M60
+MOULTRIE,M80
+MOULTRIE,M80BLX
+MOULTRIE,PANORAMIC 150
+Mustek,5LF-SF
+Mustek,6LZ
+NEC,N411i
+NEC,N412i
+NEC,N500i
+NEC,e540
+NEC,e949
+New_MSM,SAMSUNG Z370
+New_MSM,Sony Ericsson Aspen
+NIKON CORPORATION,NIKON 1 AW1
+NIKON CORPORATION,NIKON 1 J1
+NIKON CORPORATION,NIKON 1 J2
+NIKON CORPORATION,NIKON 1 J3
+NIKON CORPORATION,NIKON 1 J4
+NIKON CORPORATION,NIKON 1 J5
+NIKON CORPORATION,NIKON 1 S1
+NIKON CORPORATION,NIKON 1 S2
+NIKON CORPORATION,NIKON 1 V1
+NIKON CORPORATION,NIKON 1 V2
+NIKON CORPORATION,NIKON 1 V3
+NIKON,COOLPIX AW100
+NIKON,COOLPIX S3100
+NIKON CORPORATION,NIKON D1
+NIKON CORPORATION,NIKON D100
+NIKON CORPORATION,NIKON D1H
+NIKON CORPORATION,NIKON D1X
+NIKON CORPORATION,NIKON D200
+NIKON CORPORATION,NIKON D2H
+NIKON CORPORATION,NIKON D2Hs
+NIKON CORPORATION,NIKON D2X
+NIKON CORPORATION,NIKON D2Xs
+NIKON CORPORATION,NIKON D3
+NIKON CORPORATION,NIKON D300
+NIKON CORPORATION,NIKON D3000
+NIKON CORPORATION,NIKON D300S
+NIKON CORPORATION,NIKON D3100
+NIKON CORPORATION,NIKON D3200
+NIKON CORPORATION,NIKON D3300
+NIKON CORPORATION,NIKON D3400
+NIKON CORPORATION,NIKON D3500
+NIKON CORPORATION,NIKON D3S
+NIKON CORPORATION,NIKON D3X
+NIKON CORPORATION,NIKON D4
+NIKON CORPORATION,NIKON D40
+NIKON CORPORATION,NIKON D40X
+NIKON CORPORATION,NIKON D4S
+NIKON CORPORATION,NIKON D5
+NIKON CORPORATION,NIKON D50
+NIKON CORPORATION,NIKON D500
+NIKON CORPORATION,NIKON D5000
+NIKON CORPORATION,NIKON D5100
+NIKON CORPORATION,NIKON D5200
+NIKON CORPORATION,NIKON D5300
+NIKON CORPORATION,NIKON D5500
+NIKON CORPORATION,NIKON D5600
+NIKON CORPORATION,NIKON D6
+NIKON CORPORATION,NIKON D60
+NIKON CORPORATION,NIKON D600
+NIKON CORPORATION,NIKON D610
+NIKON CORPORATION,NIKON D70
+NIKON CORPORATION,NIKON D700
+NIKON CORPORATION,NIKON D7000
+NIKON CORPORATION,NIKON D70s
+NIKON CORPORATION,NIKON D7100
+NIKON CORPORATION,NIKON D7200
+NIKON CORPORATION,NIKON D750
+NIKON CORPORATION,NIKON D7500
+NIKON CORPORATION,NIKON D780
+NIKON CORPORATION,NIKON D80
+NIKON CORPORATION,NIKON D800
+NIKON CORPORATION,NIKON D800E
+NIKON CORPORATION,NIKON D810
+NIKON CORPORATION,NIKON D850
+NIKON CORPORATION,NIKON D90
+NIKON CORPORATION,NIKON Df
+NIKON,E2000
+NIKON,E2100
+NIKON,E2200
+NIKON,E2500
+NIKON,E3100
+NIKON,E3200
+NIKON,E3500
+NIKON,E3700
+NIKON,E4100
+NIKON,E4200
+NIKON,E4300
+NIKON,E4500
+NIKON,E4600
+NIKON,E4800
+NIKON,E5000
+NIKON,E5100
+NIKON,E5200
+NIKON,E5400
+NIKON,E5600
+NIKON,E5700
+NIKON,E5900
+NIKON,E600
+NIKON,E700
+NIKON,E7600
+NIKON,E775
+NIKON,E7900
+NIKON,E800
+NIKON,E8400
+NIKON,E8700
+NIKON,E880
+NIKON,E8800
+NIKON,E885
+NIKON,E900
+NIKON,E950
+NIKON,E990
+NIKON,E995
+NIKON,KeyMission 170
+NIKON,KeyMission 360
+NIKON,KeyMission 80
+NIKON CORPORATION,COOLPIX A
+NIKON CORPORATION,COOLPIX A1000
+NIKON,COOLPIX A300
+NIKON,COOLPIX A900
+NIKON,COOLPIX AW100
+NIKON,COOLPIX AW100s
+NIKON,COOLPIX AW110
+NIKON,COOLPIX AW110s
+NIKON,COOLPIX AW120
+NIKON,COOLPIX AW130
+NIKON,COOLPIX B500
+NIKON,COOLPIX B600
+NIKON,COOLPIX B700
+NIKON,COOLPIX L1
+NIKON,COOLPIX L10
+NIKON,COOLPIX L100
+NIKON,COOLPIX L11
+NIKON,COOLPIX L110
+NIKON,COOLPIX L12
+NIKON,COOLPIX L120
+NIKON,COOLPIX L14
+NIKON,COOLPIX L15
+NIKON,COOLPIX L16
+NIKON,COOLPIX L18
+NIKON,COOLPIX L19
+NIKON,COOLPIX L2
+NIKON,COOLPIX L20
+NIKON,COOLPIX L21
+NIKON,COOLPIX L22
+NIKON,COOLPIX L23
+NIKON,COOLPIX L24
+NIKON,COOLPIX L25
+NIKON,COOLPIX L26
+NIKON,COOLPIX L27
+NIKON,COOLPIX L28
+NIKON,COOLPIX L3
+NIKON,COOLPIX L30
+NIKON,COOLPIX L31
+NIKON,COOLPIX L310
+NIKON,COOLPIX L32
+NIKON,COOLPIX L320
+NIKON,COOLPIX L330
+NIKON,COOLPIX L340
+NIKON,COOLPIX L4
+NIKON,COOLPIX L5
+NIKON,COOLPIX L6
+NIKON,COOLPIX L610
+NIKON,COOLPIX L620
+NIKON,COOLPIX L810
+NIKON,COOLPIX L820
+NIKON,COOLPIX L830
+NIKON,COOLPIX L840
+NIKON,COOLPIX P1
+NIKON,COOLPIX P100
+NIKON CORPORATION,COOLPIX P1000
+NIKON,COOLPIX P2
+NIKON,COOLPIX P3
+NIKON,COOLPIX P300
+NIKON,COOLPIX P310
+NIKON,COOLPIX P330
+NIKON,COOLPIX P340
+NIKON,COOLPIX P4
+NIKON,COOLPIX P50
+NIKON,COOLPIX P500
+NIKON,COOLPIX P5000
+NIKON,COOLPIX P510
+NIKON,COOLPIX P5100
+NIKON,COOLPIX P520
+NIKON,COOLPIX P530
+NIKON,COOLPIX P60
+NIKON,COOLPIX P600
+NIKON,COOLPIX P6000
+NIKON,COOLPIX P610
+NIKON,COOLPIX P7000
+NIKON,COOLPIX P7100
+NIKON,COOLPIX P7700
+NIKON,COOLPIX P7800
+NIKON,COOLPIX P80
+NIKON,COOLPIX P90
+NIKON,COOLPIX P900
+NIKON CORPORATION,COOLPIX P950
+NIKON,COOLPIX S01
+NIKON,COOLPIX S02
+NIKON,COOLPIX S10
+NIKON,COOLPIX S100
+NIKON,COOLPIX S1000pj
+NIKON,COOLPIX S1100pj
+NIKON,COOLPIX S1200pj
+NIKON,COOLPIX S200
+NIKON,COOLPIX S203
+NIKON,COOLPIX S210
+NIKON,COOLPIX S220
+NIKON,COOLPIX S225
+NIKON,COOLPIX S230
+NIKON,COOLPIX S2500
+NIKON,COOLPIX S2600
+NIKON,COOLPIX S2700
+NIKON,COOLPIX S2750
+NIKON,COOLPIX S2800
+NIKON,COOLPIX S2900
+NIKON,COOLPIX S3
+NIKON,COOLPIX S30
+NIKON,COOLPIX S3000
+NIKON,COOLPIX S31
+NIKON,COOLPIX S3100
+NIKON,COOLPIX S32
+NIKON,COOLPIX S3200
+NIKON,COOLPIX S33
+NIKON,COOLPIX S3300
+NIKON,COOLPIX S3400
+NIKON,COOLPIX S3500
+NIKON,COOLPIX S3600
+NIKON,COOLPIX S3700
+NIKON,COOLPIX S4
+NIKON,COOLPIX S4000
+NIKON,COOLPIX S4100
+NIKON,COOLPIX S4150
+NIKON,COOLPIX S4200
+NIKON,COOLPIX S4300
+NIKON,COOLPIX S4400
+NIKON,COOLPIX S5
+NIKON,COOLPIX S50
+NIKON,COOLPIX S500
+NIKON,COOLPIX S50c
+NIKON,COOLPIX S51
+NIKON,COOLPIX S510
+NIKON,COOLPIX S5100
+NIKON,COOLPIX S51c
+NIKON,COOLPIX S52
+NIKON,COOLPIX S520
+NIKON,COOLPIX S5200
+NIKON,COOLPIX S52c
+NIKON,COOLPIX S5300
+NIKON,COOLPIX S550
+NIKON,COOLPIX S560
+NIKON,COOLPIX S570
+NIKON,COOLPIX S6
+NIKON,COOLPIX S60
+NIKON,COOLPIX S600
+NIKON,COOLPIX S6000
+NIKON,COOLPIX S610
+NIKON,COOLPIX S6100
+NIKON,COOLPIX S610c
+NIKON,COOLPIX S6150
+NIKON,COOLPIX S620
+NIKON,COOLPIX S6200
+NIKON,COOLPIX S630
+NIKON,COOLPIX S6300
+NIKON,COOLPIX S640
+NIKON,COOLPIX S6400
+NIKON,COOLPIX S6500
+NIKON,COOLPIX S6600
+NIKON,COOLPIX S6700
+NIKON,COOLPIX S6800
+NIKON,COOLPIX S6900
+NIKON,COOLPIX S7
+NIKON,COOLPIX S70
+NIKON,COOLPIX S700
+NIKON,COOLPIX S7000
+NIKON,COOLPIX S710
+NIKON,COOLPIX S7c
+NIKON,COOLPIX S8
+NIKON,COOLPIX S80
+NIKON,COOLPIX S8000
+NIKON,COOLPIX S800c
+NIKON,COOLPIX S8100
+NIKON,COOLPIX S810c
+NIKON,COOLPIX S8200
+NIKON,COOLPIX S9
+NIKON,COOLPIX S9100
+NIKON,COOLPIX S9200
+NIKON,COOLPIX S9300
+NIKON,COOLPIX S9400
+NIKON,COOLPIX S9500
+NIKON,COOLPIX S9600
+NIKON,COOLPIX S9700
+NIKON,COOLPIX S9900
+NIKON,COOLPIX W100
+NIKON CORPORATION,COOLPIX W150
+NIKON CORPORATION,COOLPIX W300
+FS-Nikon,LS-50
+NIKON,S1
+NIKON,S2
+NIKON,SQ
+Nikon,Nikon SUPER COOLSCAN 4000 ED
+Nikon,Nikon SUPER COOLSCAN 8000 ED
+Nikon,Nikon SUPER COOLSCAN 9000 ED
+NIKON CORPORATION,NIKON Z 30
+NIKON CORPORATION,NIKON Z 5
+NIKON CORPORATION,NIKON Z 50
+NIKON CORPORATION,NIKON Z 6
+NIKON CORPORATION,NIKON Z 6_2
+NIKON CORPORATION,NIKON Z 7
+NIKON CORPORATION,NIKON Z 7_2
+NIKON CORPORATION,NIKON Z 8
+NIKON CORPORATION,NIKON Z 9
+NIKON CORPORATION,NIKON Z f
+NIKON CORPORATION,NIKON Z fc
+NIKON CORPORATION,NIKON Z50_2
+NIKON CORPORATION,NIKON Z6_3
+Nikon,Nikon COOLSCAN IV ED
+Nikon,Nikon COOLSCAN V ED
+Nintendo,Nintendo 3DS
+Nintendo,NintendoDS
+Nokia,2330c-2
+Nokia,2680s-2
+Nokia,2690
+Nokia,2700 classic
+Nokia,2720a-2
+Nokia,2730 classic
+Nokia,3110c
+Nokia,3120classic
+Nokia,3250
+Nokia,3500c
+Nokia,3555
+Nokia,3555c
+Nokia,3600 slide
+Nokia,3600s
+Nokia,3610a
+Nokia,3710 fold
+Nokia,3720c
+Nokia,5000
+Nokia,5000d-2
+Nokia,5130c-2
+Nokia,5200
+Nokia,5220 XpressMusic
+Nokia,5228
+Nokia,5230
+Nokia,5233
+Nokia,5235
+Nokia,5250
+Nokia,5300
+Nokia,5310 XpressMusic
+Nokia,5320
+Nokia,5500
+Nokia,5530
+Nokia,5610 XpressMusic
+Nokia,5610d-1
+Nokia,5630d-1
+Nokia,5678
+Nokia,5700
+Nokia,5730S-1
+Nokia,5800 Xpres
+Nokia,6110
+Nokia,6120c
+Nokia,Nokia 6122
+Nokia,6125
+Nokia,6126
+Nokia,6131
+Nokia,6133
+Nokia,6136
+Nokia,6151
+Nokia,6208c
+Nokia,Nokia 6210
+Nokia,6210 Navig
+Nokia,6212 classic
+Nokia,6220c-1
+Nokia,6233
+Nokia,6234
+Nokia,6263
+Nokia,6267
+Nokia,6275
+Nokia,6275i
+Nokia,6288
+Nokia,6290
+Nokia,6300
+Nokia,6300i
+Nokia,6301
+Nokia,6303 classic
+Nokia,6303i classic
+Nokia,6315i
+Nokia,6500c
+Nokia,6500s-1
+Nokia,6555
+Nokia,6555b
+Nokia,6600f
+Nokia,6600i-1c
+Nokia,6600s
+Nokia,6630
+Nokia,6650 fold
+Nokia,6680
+Nokia,6681
+Nokia,6682
+Nokia,6700c-1
+Nokia,6710s
+Nokia,6720c
+Nokia,6730c
+Nokia,6730c-1
+Nokia,7020
+Nokia,7100s-2
+Nokia,7210 Supernova
+Nokia,7230
+Nokia,7310
+Nokia,7370
+Nokia,7373
+Nokia,7390
+Nokia,7500
+Nokia,7510 Supernova
+Nokia,7610 Supernova
+Nokia,7900
+Nokia,Nokia 800
+Nokia,808 PureView
+Nokia,8600 Luna
+Nokia,8800
+Nokia,8800SI
+Nokia,8800e-1
+Nokia,C1-01
+Nokia,C2-01
+Nokia,C3-00
+Nokia,C3-01
+Nokia,C5-00
+Nokia,C6-00
+Nokia,C6-01
+Nokia,C7-00
+Nokia,E5-00
+Nokia,E50
+Nokia,E51
+Nokia,E52-1
+Nokia,E55-1
+Nokia,E61i
+Nokia,E63
+Nokia,E65
+Nokia,E66
+Nokia,E7-00
+Nokia,E70
+Nokia,E71
+Nokia,E71x
+Nokia,E72-1
+Nokia,E75-1
+Nokia,E90
+Nokia,Lumia 1020
+Nokia,Lumia 1320
+Nokia,Lumia 1520
+Nokia,Lumia 520
+Nokia,Nokia Lumia 610
+Nokia,Lumia 620
+Nokia,Lumia 625
+Nokia,Lumia 630
+Nokia,Lumia 635
+Nokia,Nokia Lumia 710
+Nokia,Lumia 735
+Nokia,Nokia Lumia 800
+Nokia,Lumia 820
+Nokia,Lumia 822
+Nokia,Lumia 830
+Nokia,Nokia Lumia 900
+Nokia,Lumia 920
+Nokia,Lumia 925
+Nokia,N70-1
+Nokia,N70-5
+Nokia,N71
+Nokia,N72
+Nokia,N73
+Nokia,N75
+Nokia,N76
+Nokia,N77
+Nokia,N78
+Nokia,N79
+Nokia,N8
+Nokia,N8-00
+Nokia,N80
+Nokia,Nokia N81
+Nokia,N82
+Nokia,N85
+Nokia,N86 8MP
+Nokia,N9
+Nokia,N90-1
+Nokia,N900
+Nokia,N91
+Nokia,N93
+Nokia,N93i
+Nokia,N95
+Nokia,N95 8GB
+Nokia,N96
+Nokia,N97
+Nokia,N97 mini
+Nokia,X2-00
+Nokia,X3-00
+Nokia,X5-01
+Nokia,X6-00
+NORITSU KOKI,EZ Controller
+NORITSU KOKI,QSS-29_31
+NORITSU KOKI,QSS-30
+NORITSU KOKI,QSS-31
+NORITSU KOKI,QSS-32_33
+NORITSU KOKI,SI-2000
+Noritsu,S2 Film Scanner
+Noritsu,SI-1080 Film Scanner Model DLS1640
+Nucam Corporation,SP-1300
+OM Digital Solutions,OM-1
+OM Digital Solutions,OM-1MarkII
+OM Digital Solutions,OM-3
+OM Digital Solutions,OM-5
+OM Digital Solutions,TG-7
+OMG LIFE,AutographerV1
+ODYS,MC-A5
+ODYS,MDV 30
+ODYS Corp.,Pocketcam 5200
+ODYS,SLIM X5
+ODYS,SLIM5L PRO-II
+ODYS,SLIM5L-II
+ODYS,Slim 6L Pro
+ODYS,Slim X6
+OLYMPUS IMAGING CORP.,AIR-A01
+OLYMPUS CORPORATION,AZ-1
+OLYMPUS IMAGING CORP.,AZ-2ZOOM
+"OLYMPUS OPTICAL CO.,LTD",C-1
+"OLYMPUS OPTICAL CO.,LTD","C-1Z,D-150Z"
+OLYMPUS CORPORATION,C-5000Z
+"OLYMPUS OPTICAL CO.,LTD","C100,D370"
+"OLYMPUS OPTICAL CO.,LTD","C120,D380"
+"OLYMPUS OPTICAL CO.,LTD","C150,D390"
+OLYMPUS CORPORATION,"C160,D395"
+OLYMPUS IMAGING CORP.,"C170,D425"
+OLYMPUS IMAGING CORP.,"C180,D435"
+"OLYMPUS OPTICAL CO.,LTD",C2000Z
+"OLYMPUS OPTICAL CO.,LTD","C200Z,D510Z"
+"OLYMPUS OPTICAL CO.,LTD",C2020Z
+"OLYMPUS OPTICAL CO.,LTD",C2040Z
+"OLYMPUS OPTICAL CO.,LTD",C21
+"OLYMPUS OPTICAL CO.,LTD",C2100UZ
+"OLYMPUS OPTICAL CO.,LTD",C211Z
+"OLYMPUS OPTICAL CO.,LTD",C21T.commu
+"OLYMPUS OPTICAL CO.,LTD",C2500L
+"OLYMPUS OPTICAL CO.,LTD","C2,D230"
+"OLYMPUS OPTICAL CO.,LTD","C2Z,D520Z,C220Z"
+"OLYMPUS OPTICAL CO.,LTD",C3000Z
+"OLYMPUS OPTICAL CO.,LTD","C300Z,D550Z"
+"OLYMPUS OPTICAL CO.,LTD",C3030Z
+"OLYMPUS OPTICAL CO.,LTD",C3040Z
+"OLYMPUS OPTICAL CO.,LTD","C3100Z,C3020Z"
+"OLYMPUS OPTICAL CO.,LTD",C4040Z
+"OLYMPUS OPTICAL CO.,LTD",C40Z
+"OLYMPUS OPTICAL CO.,LTD","C40Z,D40Z"
+"OLYMPUS OPTICAL CO.,LTD","C4100Z,C4000Z"
+OLYMPUS CORPORATION,C460ZdelSol
+"OLYMPUS OPTICAL CO.,LTD",C5050Z
+OLYMPUS CORPORATION,C5060WZ
+OLYMPUS IMAGING CORP.,"C55Z,C5500Z"
+"OLYMPUS OPTICAL CO.,LTD",C700UZ
+OLYMPUS IMAGING CORP.,C7070WZ
+OLYMPUS IMAGING CORP.,"C70Z,C7000Z"
+OLYMPUS IMAGING CORP.,"C70Z,C7000Z"
+"OLYMPUS OPTICAL CO.,LTD",C720UZ
+OLYMPUS CORPORATION,C725UZ
+"OLYMPUS OPTICAL CO.,LTD",C730UZ
+"OLYMPUS OPTICAL CO.,LTD",C740UZ
+OLYMPUS CORPORATION,C745UZ
+"OLYMPUS OPTICAL CO.,LTD",C750UZ
+OLYMPUS CORPORATION,C755UZ
+OLYMPUS CORPORATION,C760UZ
+OLYMPUS CORPORATION,C765UZ
+OLYMPUS CORPORATION,C770UZ
+OLYMPUS CORPORATION,C8080WZ
+"OLYMPUS OPTICAL CO.,LTD","C830L,D340R"
+"OLYMPUS OPTICAL CO.,LTD","C830L,D340R"
+"OLYMPUS OPTICAL CO.,LTD","C860L,D360L"
+"OLYMPUS OPTICAL CO.,LTD","C860L,D360L"
+"OLYMPUS OPTICAL CO.,LTD","C900Z,D400Z"
+"OLYMPUS OPTICAL CO.,LTD","C920Z,D450Z"
+"OLYMPUS OPTICAL CO.,LTD","C960Z,D460Z"
+"OLYMPUS OPTICAL CO.,LTD","C990Z,D490Z"
+"OLYMPUS OPTICAL CO.,LTD","C990ZS,D490Z"
+OLYMPUS IMAGING CORP.,"D555Z,C315Z"
+OLYMPUS IMAGING CORP.,"D595Z,C500Z"
+OLYMPUS CORPORATION,E-1
+"OLYMPUS OPTICAL CO.,LTD",E-10
+"OLYMPUS OPTICAL CO.,LTD","E-20,E-20N,E-20P"
+OLYMPUS IMAGING CORP.,E-3
+OLYMPUS IMAGING CORP.,E-30
+OLYMPUS IMAGING CORP.,E-300
+OLYMPUS IMAGING CORP.,E-330
+OLYMPUS IMAGING CORP.,E-400
+OLYMPUS IMAGING CORP.,E-410
+OLYMPUS IMAGING CORP.,E-420
+OLYMPUS IMAGING CORP.,E-450
+OLYMPUS IMAGING CORP.,E-5
+OLYMPUS IMAGING CORP.,E-500
+OLYMPUS IMAGING CORP.,E-510
+OLYMPUS IMAGING CORP.,E-520
+OLYMPUS IMAGING CORP.,E-600
+OLYMPUS IMAGING CORP.,E-620
+OLYMPUS IMAGING CORP.,E-M1
+OLYMPUS IMAGING CORP.,E-M10
+OLYMPUS CORPORATION,E-M10 Mark III
+OLYMPUS CORPORATION,E-M10MarkII
+OLYMPUS CORPORATION,E-M10MarkIIIS
+OLYMPUS CORPORATION,E-M10MarkIV
+OLYMPUS CORPORATION,E-M1MarkII
+OLYMPUS CORPORATION,E-M1MarkIII
+OLYMPUS CORPORATION,E-M1X
+OLYMPUS IMAGING CORP.,E-M5
+OLYMPUS IMAGING CORP.,E-M5MarkII
+OLYMPUS CORPORATION,E-M5MarkIII
+OLYMPUS IMAGING CORP.,E-P1
+OLYMPUS IMAGING CORP.,E-P2
+OLYMPUS IMAGING CORP.,E-P3
+OLYMPUS IMAGING CORP.,E-P5
+OLYMPUS CORPORATION,E-P7
+OLYMPUS IMAGING CORP.,E-PL1
+OLYMPUS CORPORATION,E-PL10
+OLYMPUS IMAGING CORP.,E-PL1s
+OLYMPUS IMAGING CORP.,E-PL2
+OLYMPUS IMAGING CORP.,E-PL3
+OLYMPUS IMAGING CORP.,E-PL5
+OLYMPUS IMAGING CORP.,E-PL6
+OLYMPUS IMAGING CORP.,E-PL7
+OLYMPUS CORPORATION,E-PL8
+OLYMPUS CORPORATION,E-PL9
+OLYMPUS IMAGING CORP.,E-PM1
+OLYMPUS IMAGING CORP.,E-PM2
+"OLYMPUS OPTICAL CO.,LTD",E100RS
+OLYMPUS IMAGING CORP.,"FE-120,X-700"
+OLYMPUS IMAGING CORP.,"FE-130,X-720"
+OLYMPUS IMAGING CORP.,"FE-140,X-725"
+OLYMPUS IMAGING CORP.,"FE100,X710"
+OLYMPUS IMAGING CORP.,"FE110,X705"
+OLYMPUS IMAGING CORP.,"FE115,X715"
+OLYMPUS IMAGING CORP.,"FE150,X730"
+OLYMPUS IMAGING CORP.,"FE15,X10"
+OLYMPUS IMAGING CORP.,"FE160,X735"
+OLYMPUS IMAGING CORP.,"FE170,X760"
+OLYMPUS IMAGING CORP.,FE180/X745
+OLYMPUS IMAGING CORP.,FE190/X750
+OLYMPUS IMAGING CORP.,FE200
+OLYMPUS IMAGING CORP.,"FE20,X15,C25"
+OLYMPUS IMAGING CORP.,"FE210,X775"
+OLYMPUS IMAGING CORP.,"FE220,X785"
+OLYMPUS IMAGING CORP.,FE230/X790
+OLYMPUS IMAGING CORP.,FE240/X795
+OLYMPUS IMAGING CORP.,FE250/X800
+OLYMPUS IMAGING CORP.,"FE25,X20"
+OLYMPUS IMAGING CORP.,"FE26,X21"
+OLYMPUS IMAGING CORP.,"FE270,X815,C510"
+OLYMPUS IMAGING CORP.,"FE280,X820,C520"
+OLYMPUS IMAGING CORP.,"FE290,X825"
+OLYMPUS IMAGING CORP.,"FE3000,X890"
+OLYMPUS IMAGING CORP.,"FE300,X830"
+OLYMPUS IMAGING CORP.,"FE3010,X895"
+OLYMPUS IMAGING CORP.,"FE310,X840,C530"
+OLYMPUS IMAGING CORP.,"FE320,X835,C540"
+OLYMPUS IMAGING CORP.,"FE330,X845,C550"
+OLYMPUS IMAGING CORP.,"FE340,X855,C560"
+OLYMPUS IMAGING CORP.,"FE350WIDE,X865"
+OLYMPUS IMAGING CORP.,"FE35,X30"
+OLYMPUS IMAGING CORP.,"FE360,X875,C570"
+OLYMPUS IMAGING CORP.,"FE370,X880,C575"
+OLYMPUS IMAGING CORP.,"FE4000,X920,X925"
+OLYMPUS IMAGING CORP.,"FE4010,X930"
+OLYMPUS IMAGING CORP.,"FE4020,X940"
+OLYMPUS IMAGING CORP.,"FE4030,X950"
+OLYMPUS IMAGING CORP.,FE4040
+OLYMPUS IMAGING CORP.,"FE4050,X970"
+OLYMPUS IMAGING CORP.,"FE45,X40"
+OLYMPUS IMAGING CORP.,"FE46,X41,X42"
+OLYMPUS IMAGING CORP.,"FE47,X43"
+OLYMPUS IMAGING CORP.,"FE5000,X905"
+OLYMPUS IMAGING CORP.,"FE5010,X915"
+OLYMPUS IMAGING CORP.,"FE5020,X935"
+OLYMPUS IMAGING CORP.,"FE5030,X965,X960"
+OLYMPUS IMAGING CORP.,FE5035
+OLYMPUS IMAGING CORP.,"FE5040,X980"
+OLYMPUS IMAGING CORP.,"FE5050,X985"
+OLYMPUS CORPORATION,FerrariMODEL2003
+OLYMPUS CORPORATION,FerrariMODEL2004
+OLYMPUS IMAGING CORP.,IR-300
+OLYMPUS IMAGING CORP.,IR-500
+OLYMPUS CORPORATION,PEN-F
+OLYMPUS IMAGING CORP.,SH-1
+OLYMPUS IMAGING CORP.,SH-2
+OLYMPUS IMAGING CORP.,SH-21
+OLYMPUS IMAGING CORP.,SH-25MR
+OLYMPUS IMAGING CORP.,SH-50
+OLYMPUS IMAGING CORP.,SH-60
+OLYMPUS IMAGING CORP.,SP-100EE
+OLYMPUS IMAGING CORP.,SP-610UZ
+OLYMPUS IMAGING CORP.,SP-620UZ
+OLYMPUS IMAGING CORP.,SP-720UZ
+OLYMPUS IMAGING CORP.,SP-810UZ
+OLYMPUS IMAGING CORP.,SP-820UZ
+OLYMPUS IMAGING CORP.,SP310
+OLYMPUS IMAGING CORP.,SP320
+OLYMPUS IMAGING CORP.,SP350
+OLYMPUS IMAGING CORP.,SP500UZ
+OLYMPUS IMAGING CORP.,SP510UZ
+OLYMPUS IMAGING CORP.,SP550UZ
+OLYMPUS IMAGING CORP.,SP560UZ
+OLYMPUS IMAGING CORP.,SP565UZ
+OLYMPUS IMAGING CORP.,SP570UZ
+OLYMPUS IMAGING CORP.,SP590UZ
+OLYMPUS IMAGING CORP.,SP600UZ
+OLYMPUS IMAGING CORP.,SP700
+OLYMPUS IMAGING CORP.,SP800UZ
+OLYMPUS IMAGING CORP.,SZ-10
+OLYMPUS IMAGING CORP.,SZ-11
+OLYMPUS IMAGING CORP.,SZ-12
+OLYMPUS IMAGING CORP.,SZ-14
+OLYMPUS IMAGING CORP.,"SZ-15,DZ-100"
+OLYMPUS IMAGING CORP.,"SZ-16,DZ-105"
+OLYMPUS IMAGING CORP.,SZ-20
+OLYMPUS IMAGING CORP.,SZ-30MR
+OLYMPUS IMAGING CORP.,SZ-31MR
+OLYMPUS IMAGING CORP.,STYLUS1
+OLYMPUS IMAGING CORP.,StylusTough-3000
+OLYMPUS IMAGING CORP.,StylusTough-6020
+OLYMPUS IMAGING CORP.,StylusTough-8010
+OLYMPUS IMAGING CORP.,"T10,X27"
+OLYMPUS IMAGING CORP.,TG-1
+OLYMPUS IMAGING CORP.,TG-2
+OLYMPUS IMAGING CORP.,TG-3
+OLYMPUS IMAGING CORP.,TG-310
+OLYMPUS IMAGING CORP.,TG-320
+OLYMPUS CORP.,TG-4
+OLYMPUS CORPORATION,TG-5
+OLYMPUS CORPORATION,TG-6
+OLYMPUS IMAGING CORP.,TG-610
+OLYMPUS IMAGING CORP.,TG-615
+OLYMPUS IMAGING CORP.,TG-620
+OLYMPUS IMAGING CORP.,TG-630
+OLYMPUS IMAGING CORP.,TG-810
+OLYMPUS IMAGING CORP.,TG-820
+OLYMPUS IMAGING CORP.,TG-830
+OLYMPUS IMAGING CORP.,TG-835
+OLYMPUS IMAGING CORP.,TG-850
+OLYMPUS IMAGING CORP.,TG-860
+OLYMPUS CORPORATION,TG-870
+OLYMPUS CORPORATION,TG-TRACKER
+OLYMPUS IMAGING CORP.,"VG110,D700"
+OLYMPUS IMAGING CORP.,"VG120,D705"
+OLYMPUS IMAGING CORP.,"VG130,D710"
+OLYMPUS IMAGING CORP.,"VG140,D715"
+OLYMPUS IMAGING CORP.,"VG145,VG140,D715"
+OLYMPUS IMAGING CORP.,VG170
+OLYMPUS IMAGING CORP.,VH210
+OLYMPUS IMAGING CORP.,VH410
+OLYMPUS IMAGING CORP.,"VR310,D720"
+OLYMPUS IMAGING CORP.,"VR320,D725"
+OLYMPUS IMAGING CORP.,"VR330,D730"
+OLYMPUS IMAGING CORP.,"VR340,D750"
+"OLYMPUS OPTICAL CO.,LTD",X-1
+"OLYMPUS OPTICAL CO.,LTD","X-2,C-50Z"
+OLYMPUS CORPORATION,"X-3,C-60Z"
+OLYMPUS CORPORATION,"X-3,C-60Z"
+OLYMPUS CORPORATION,"X100,D540Z,C310Z"
+"OLYMPUS OPTICAL CO.,LTD","X200,D560Z,C350Z"
+OLYMPUS CORPORATION,"X250,D560Z,C350Z"
+"OLYMPUS OPTICAL CO.,LTD","X300,D565Z,C450Z"
+OLYMPUS CORPORATION,"X350,D575Z,C360Z"
+OLYMPUS CORPORATION,"X400,D580Z,C460Z"
+OLYMPUS_IMAGING_CORP.,"X450,D535Z,C370Z"
+OLYMPUS IMAGING CORP.,"X500,D590Z,C470Z"
+OLYMPUS IMAGING CORP.,"X550,D545Z,C480Z"
+OLYMPUS IMAGING CORP.,X560WP
+OLYMPUS IMAGING CORP.,"X600,D630,FE5500"
+OLYMPUS IMAGING CORP.,XZ-1
+OLYMPUS IMAGING CORP.,XZ-10
+OLYMPUS IMAGING CORP.,XZ-2
+OLYMPUS IMAGING CORP.,u-7040
+OLYMPUS IMAGING CORP.,u-7050
+OLYMPUS IMAGING CORP.,"u-miniD,Stylus V"
+OLYMPUS IMAGING CORP.,"u-miniS,StylusVS"
+OLYMPUS IMAGING CORP.,u1000/S1000
+OLYMPUS IMAGING CORP.,"u1010,S1010"
+OLYMPUS IMAGING CORP.,"u1020,S1020"
+OLYMPUS IMAGING CORP.,"u1030SW,S1030SW"
+OLYMPUS IMAGING CORP.,"u1040,S1040"
+OLYMPUS IMAGING CORP.,"u1050SW,S1050SW"
+OLYMPUS IMAGING CORP.,"u1060,S1060"
+"OLYMPUS OPTICAL CO.,LTD","u10D,S300D,u300D"
+OLYMPUS CORPORATION,"u10D,S300D,u300D"
+"OLYMPUS OPTICAL CO.,LTD","u10D,S300D,u300D"
+OLYMPUS IMAGING CORP.,"u1200,S1200"
+OLYMPUS CORPORATION,u15D
+"OLYMPUS OPTICAL CO.,LTD","u20D,S400D,u400D"
+OLYMPUS CORPORATION,u25D
+OLYMPUS CORPORATION,"u30D,S410D,u410D"
+OLYMPUS IMAGING CORP.,"u40D,S500,uD500"
+OLYMPUS IMAGING CORP.,u5000
+OLYMPUS IMAGING CORP.,"u5010,S5010"
+OLYMPUS IMAGING CORP.,"u550WP,S550WP"
+OLYMPUS IMAGING CORP.,"u7000,S7000"
+OLYMPUS IMAGING CORP.,"u700,S700"
+OLYMPUS IMAGING CORP.,"u7010,S7010"
+OLYMPUS IMAGING CORP.,"u7020,S7020"
+OLYMPUS IMAGING CORP.,"u7030,S7030"
+OLYMPUS IMAGING CORP.,"u7040,S7040"
+OLYMPUS IMAGING CORP.,"u710,S710"
+OLYMPUS IMAGING CORP.,"u720SW,S720SW"
+OLYMPUS IMAGING CORP.,"u725SW,S725SW"
+OLYMPUS IMAGING CORP.,u730/S730
+OLYMPUS IMAGING CORP.,"u740,S740"
+OLYMPUS IMAGING CORP.,"u750,S750"
+OLYMPUS IMAGING CORP.,"u760,S760"
+OLYMPUS IMAGING CORP.,"u770SW,S770SW"
+OLYMPUS IMAGING CORP.,"u780,S780"
+OLYMPUS IMAGING CORP.,"u790SW,S790SW"
+OLYMPUS IMAGING CORP.,"u795SW,S795SW"
+OLYMPUS IMAGING CORP.,u810/S810
+OLYMPUS IMAGING CORP.,"u820,S820"
+OLYMPUS IMAGING CORP.,"u830,S830"
+OLYMPUS IMAGING CORP.,"u840,S840"
+OLYMPUS IMAGING CORP.,"u850SW,S850SW"
+OLYMPUS IMAGING CORP.,"u850SW,S850SW"
+OLYMPUS IMAGING CORP.,"u9000,S9000"
+OLYMPUS IMAGING CORP.,"u9010,S9010"
+OLYMPUS IMAGING CORP.,"uD600,S600"
+OLYMPUS IMAGING CORP.,"uD800,S800"
+OLYMPUS IMAGING CORP.,"uT6000,ST6000"
+OLYMPUS IMAGING CORP.,"uT6010,ST6010"
+OLYMPUS IMAGING CORP.,"uT8000,ST8000"
+OLYMPUS IMAGING CORP.,uTough-3000
+OnePlus,ONEPLUS A3003
+OnePlus,ONEPLUS A5010
+OnePlus,ONEPLUS A6003
+OnePlus,GM1913
+OnePlus,HD1913
+OnePlus,IN2017
+OnePlus,IN2023
+OnePlus,OnePlus Open
+Oregon Scientific,DS6639
+Oregon Scientific,DS8228
+Oregon Scientific,DS9610
+Oregon Scientific,DS9810
+Oregon Scientific,ds6638
+PLA100Z,Polaroid i1032
+Packard Bell,DSC-200
+Packard Bell,DSC-220
+Panasonic,AG-HSC1U
+Panasonic,DC-FT7
+Panasonic,DC-FZ10002
+Panasonic,DC-FZ80
+Panasonic,DC-FZ82
+Panasonic,DC-G100
+Panasonic,DC-G9
+Panasonic,DC-G90
+Panasonic,DC-G91
+Panasonic,DC-G95
+Panasonic,DC-G9M2
+Panasonic,DC-GH5
+Panasonic,DC-GH5M2
+Panasonic,DC-GH5S
+Panasonic,DC-GH6
+Panasonic,DC-GH7
+Panasonic,DC-GX800
+Panasonic,DC-GX850
+Panasonic,DC-GX880
+Panasonic,DC-GX9
+Panasonic,DC-LX100M2
+Panasonic,DC-S1
+Panasonic,DC-S1H
+Panasonic,DC-S1M2
+Panasonic,DC-S1M2ES
+Panasonic,DC-S1R
+Panasonic,DC-S1RM2
+Panasonic,DC-S5
+Panasonic,DC-S5M2
+Panasonic,DC-S5M2X
+Panasonic,DC-S9
+Panasonic,DC-TZ200
+Panasonic,DC-TZ90
+Panasonic,DC-TZ95
+Panasonic,DC-ZS200
+Panasonic,DC-ZS70
+Panasonic,DC-ZS80
+Panasonic,DMC-3D1
+Panasonic,DMC-CM1
+Panasonic,DMC-F1
+Panasonic,DMC-F2
+Panasonic,DMC-F3
+Panasonic,DMC-F5
+Panasonic,DMC-F7
+Panasonic,DMC-FH1
+Panasonic,DMC-FH2
+Panasonic,DMC-FH20
+Panasonic,DMC-FH22
+Panasonic,DMC-FH25
+Panasonic,DMC-FH27
+Panasonic,DMC-FH3
+Panasonic,DMC-FH5
+Panasonic,DMC-FH6
+Panasonic,DMC-FH7
+Panasonic,DMC-FH8
+Panasonic,DMC-FP1
+Panasonic,DMC-FP2
+Panasonic,DMC-FP3
+Panasonic,DMC-FP5
+Panasonic,DMC-FP7
+Panasonic,DMC-FP8
+Panasonic,DMC-FS1
+Panasonic,DMC-FS10
+Panasonic,DMC-FS11
+Panasonic,DMC-FS15
+Panasonic,DMC-FS18
+Panasonic,DMC-FS2
+Panasonic,DMC-FS20
+Panasonic,DMC-FS22
+Panasonic,DMC-FS25
+Panasonic,DMC-FS3
+Panasonic,DMC-FS30
+Panasonic,DMC-FS33
+Panasonic,DMC-FS4
+Panasonic,DMC-FS42
+Panasonic,DMC-FS5
+Panasonic,DMC-FS6
+Panasonic,DMC-FS62
+Panasonic,DMC-FS7
+Panasonic,DMC-FS8
+Panasonic,DMC-FS9
+Panasonic,DMC-FT1
+Panasonic,DMC-FT2
+Panasonic,DMC-FT20
+Panasonic,DMC-FT25
+Panasonic,DMC-FT3
+Panasonic,DMC-FT30
+Panasonic,DMC-FT4
+Panasonic,DMC-FT5
+Panasonic,DMC-FX01
+Panasonic,DMC-FX07
+Panasonic,DMC-FX1
+Panasonic,DMC-FX10
+Panasonic,DMC-FX100
+Panasonic,DMC-FX12
+Panasonic,DMC-FX150
+Panasonic,DMC-FX2
+Panasonic,DMC-FX3
+Panasonic,DMC-FX30
+Panasonic,DMC-FX33
+Panasonic,DMC-FX35
+Panasonic,DMC-FX36
+Panasonic,DMC-FX37
+Panasonic,DMC-FX38
+Panasonic,DMC-FX40
+Panasonic,DMC-FX5
+Panasonic,DMC-FX50
+Panasonic,DMC-FX500
+Panasonic,DMC-FX520
+Panasonic,DMC-FX55
+Panasonic,DMC-FX550
+Panasonic,DMC-FX60
+Panasonic,DMC-FX66
+Panasonic,DMC-FX7
+Panasonic,DMC-FX70
+Panasonic,DMC-FX700
+Panasonic,DMC-FX75
+Panasonic,DMC-FX77
+Panasonic,DMC-FX78
+Panasonic,DMC-FX8
+Panasonic,DMC-FX80
+Panasonic,DMC-FX9
+Panasonic,DMC-FX90
+Panasonic,DMC-FZ1
+Panasonic,DMC-FZ10
+Panasonic,DMC-FZ100
+Panasonic,DMC-FZ1000
+Panasonic,DMC-FZ15
+Panasonic,DMC-FZ150
+Panasonic,DMC-FZ18
+Panasonic,DMC-FZ2
+Panasonic,DMC-FZ20
+Panasonic,DMC-FZ200
+Panasonic,DMC-FZ2000
+Panasonic,DMC-FZ2500
+Panasonic,DMC-FZ28
+Panasonic,DMC-FZ3
+Panasonic,DMC-FZ30
+Panasonic,DMC-FZ300
+Panasonic,DMC-FZ330
+Panasonic,DMC-FZ35
+Panasonic,DMC-FZ38
+Panasonic,DMC-FZ4
+Panasonic,DMC-FZ40
+Panasonic,DMC-FZ45
+Panasonic,DMC-FZ47
+Panasonic,DMC-FZ48
+Panasonic,DMC-FZ5
+Panasonic,DMC-FZ50
+Panasonic,DMC-FZ60
+Panasonic,DMC-FZ62
+Panasonic,DMC-FZ7
+Panasonic,DMC-FZ70
+Panasonic,DMC-FZ72
+Panasonic,DMC-FZ8
+Panasonic,DMC-G1
+Panasonic,DMC-G10
+Panasonic,DMC-G2
+Panasonic,DMC-G3
+Panasonic,DMC-G5
+Panasonic,DMC-G6
+Panasonic,DMC-G7
+Panasonic,DMC-G80
+Panasonic,DMC-G85
+Panasonic,DMC-GF1
+Panasonic,DMC-GF2
+Panasonic,DMC-GF3
+Panasonic,DMC-GF5
+Panasonic,DMC-GF6
+Panasonic,DMC-GF7
+Panasonic,DMC-GH1
+Panasonic,DMC-GH2
+Panasonic,DMC-GH3
+Panasonic,DMC-GH4
+Panasonic,DMC-GM1
+Panasonic,DMC-GM5
+Panasonic,DMC-GX1
+Panasonic,DMC-GX7
+Panasonic,DMC-GX8
+Panasonic,DMC-GX80
+Panasonic,DMC-GX85
+Panasonic,DMC-L1
+Panasonic,DMC-L10
+Panasonic,DMC-LC1
+Panasonic,DMC-LC20
+Panasonic,DMC-LC33
+Panasonic,DMC-LC40
+Panasonic,DMC-LC43
+Panasonic,DMC-LC5
+Panasonic,DMC-LC50
+Panasonic,DMC-LC70
+Panasonic,DMC-LC80
+Panasonic,DMC-LF1
+Panasonic,DMC-LS1
+Panasonic,DMC-LS2
+Panasonic,DMC-LS3
+Panasonic,DMC-LS5
+Panasonic,DMC-LS60
+Panasonic,DMC-LS65
+Panasonic,DMC-LS70
+Panasonic,DMC-LS75
+Panasonic,DMC-LS80
+Panasonic,DMC-LS85
+Panasonic,DMC-LS86
+Panasonic,DMC-LX1
+Panasonic,DMC-LX10
+Panasonic,DMC-LX100
+Panasonic,DMC-LX15
+Panasonic,DMC-LX2
+Panasonic,DMC-LX3
+Panasonic,DMC-LX5
+Panasonic,DMC-LX7
+Panasonic,DMC-LZ1
+Panasonic,DMC-LZ10
+Panasonic,DMC-LZ2
+Panasonic,DMC-LZ20
+Panasonic,DMC-LZ3
+Panasonic,DMC-LZ30
+Panasonic,DMC-LZ4
+Panasonic,DMC-LZ40
+Panasonic,DMC-LZ5
+Panasonic,DMC-LZ6
+Panasonic,DMC-LZ7
+Panasonic,DMC-LZ8
+Panasonic,DMC-S1
+Panasonic,DMC-S2
+Panasonic,DMC-S3
+Panasonic,DMC-S5
+Panasonic,DMC-SZ1
+Panasonic,DMC-SZ10
+Panasonic,DMC-SZ3
+Panasonic,DMC-SZ5
+Panasonic,DMC-SZ7
+Panasonic,DMC-SZ9
+Panasonic,DMC-TS1
+Panasonic,DMC-TS10
+Panasonic,DMC-TS2
+Panasonic,DMC-TS20
+Panasonic,DMC-TS3
+Panasonic,DMC-TS4
+Panasonic,DMC-TS5
+Panasonic,DMC-TX1
+Panasonic,DMC-TZ1
+Panasonic,DMC-TZ10
+Panasonic,DMC-TZ100
+Panasonic,DMC-TZ11
+Panasonic,DMC-TZ15
+Panasonic,DMC-TZ18
+Panasonic,DMC-TZ19
+Panasonic,DMC-TZ2
+Panasonic,DMC-TZ20
+Panasonic,DMC-TZ22
+Panasonic,DMC-TZ25
+Panasonic,DMC-TZ3
+Panasonic,DMC-TZ30
+Panasonic,DMC-TZ35
+Panasonic,DMC-TZ4
+Panasonic,DMC-TZ40
+Panasonic,DMC-TZ41
+Panasonic,DMC-TZ5
+Panasonic,DMC-TZ50
+Panasonic,DMC-TZ57
+Panasonic,DMC-TZ6
+Panasonic,DMC-TZ60
+Panasonic,DMC-TZ7
+Panasonic,DMC-TZ70
+Panasonic,DMC-TZ8
+Panasonic,DMC-TZ80
+Panasonic,DMC-XS1
+Panasonic,DMC-XS3
+Panasonic,DMC-ZR3
+Panasonic,DMC-ZS10
+Panasonic,DMC-ZS100
+Panasonic,DMC-ZS15
+Panasonic,DMC-ZS19
+Panasonic,DMC-ZS20
+Panasonic,DMC-ZS25
+Panasonic,DMC-ZS40
+Panasonic,DMC-ZS5
+Panasonic,DMC-ZS50
+Panasonic,DMC-ZS60
+Panasonic,DMC-ZS7
+Panasonic,DMC-ZS8
+Panasonic,DMC-ZX1
+Panasonic,DMC-ZX3
+Panasonic,HC-V727
+Panasonic,HDC-DX1
+Panasonic,HDC-HS100
+Panasonic,HDC-HS20
+Panasonic,HDC-HS200
+Panasonic,HDC-HS300
+Panasonic,HDC-HS60
+Panasonic,HDC-HS700
+Panasonic,HDC-HS80
+Panasonic,HDC-HS9
+Panasonic,HDC-MDH1
+Panasonic,HDC-SD1
+Panasonic,HDC-SD10
+Panasonic,HDC-SD100
+Panasonic,HDC-SD20
+Panasonic,HDC-SD200
+Panasonic,HDC-SD40
+Panasonic,HDC-SD5
+Panasonic,HDC-SD60
+Panasonic,HDC-SD600
+Panasonic,HDC-SD700
+Panasonic,HDC-SD80
+Panasonic,HDC-SD800
+Panasonic,HDC-SD9
+Panasonic,HDC-SD90
+Panasonic,HDC-SDT750
+Panasonic,HDC-SDX1
+Panasonic,HDC-SX5
+Panasonic,HDC-TM10
+Panasonic,HDC-TM15
+Panasonic,HDC-TM20
+Panasonic,HDC-TM200
+Panasonic,HDC-TM300
+Panasonic,HDC-TM35
+Panasonic,HDC-TM55
+Panasonic,HDC-TM60
+Panasonic,HDC-TM700
+Panasonic,HDC-TM80
+Panasonic,HDC-TM90
+Panasonic,HDC-TM900
+Panasonic,HM-TA1
+Panasonic,HX-A1
+Panasonic,NV-C7
+Panasonic,NV-DCF7
+Panasonic,NV-DS37
+Panasonic,NV-DS38
+Panasonic,NV-DS65
+Panasonic,NV-DS88
+Panasonic,NV-EX21
+Panasonic,NV-GS100
+Panasonic,NV-GS120
+Panasonic,NV-GS140
+Panasonic,NV-GS15
+Panasonic,NV-GS150
+Panasonic,NV-GS180
+Panasonic,NV-GS200
+Panasonic,NV-GS21
+Panasonic,NV-GS230
+Panasonic,NV-GS25
+Panasonic,NV-GS250
+Panasonic,NV-GS258
+Panasonic,NV-GS28
+Panasonic,NV-GS280
+Panasonic,NV-GS300
+Panasonic,NV-GS320
+Panasonic,NV-GS330
+Panasonic,NV-GS35
+Panasonic,NV-GS4
+Panasonic,NV-GS40
+Panasonic,NV-GS400
+Panasonic,NV-GS47
+Panasonic,NV-GS5
+Panasonic,NV-GS50
+Panasonic,NV-GS500
+Panasonic,NV-GS55
+Panasonic,NV-GS57
+Panasonic,NV-GS65
+Panasonic,NV-GS70
+Panasonic,NV-GS75
+Panasonic,NV-GS85
+Panasonic,NV-GX7
+Panasonic,NV-MX2500
+Panasonic,NV-MX300
+Panasonic,NV-MX3000
+Panasonic,NV-MX350
+Panasonic,NV-MX5
+Panasonic,NV-MX500
+Panasonic,NV-MX5000
+Panasonic,NV-MX7
+Panasonic,NV-MX8
+Panasonic,PV-2001
+Panasonic,PV-D2002
+Panasonic,PV-DC2090
+Panasonic,PV-DC252
+Panasonic,PV-DC2590
+Panasonic,PV-DC3000
+Panasonic,PV-DC352
+Panasonic,PV-DV203
+Panasonic,PV-DV702
+Panasonic,PV-DV901
+Panasonic,PV-DV951
+Panasonic,PV-DV953
+Panasonic,PV-GS12
+Panasonic,PV-GS120
+Panasonic,PV-GS13
+Panasonic,PV-GS14
+Panasonic,PV-GS15
+Panasonic,PV-GS150
+Panasonic,PV-GS16
+Panasonic,PV-GS19
+Panasonic,PV-GS2
+Panasonic,PV-GS200
+Panasonic,PV-GS250
+Panasonic,PV-GS300
+Panasonic,PV-GS31
+Panasonic,PV-GS320
+Panasonic,PV-GS34
+Panasonic,PV-GS35
+Panasonic,PV-GS36
+Panasonic,PV-GS39
+Panasonic,PV-GS400
+Panasonic,PV-GS50
+Panasonic,PV-GS55
+Panasonic,PV-GS59
+Panasonic,PV-GS70
+Panasonic,PV-GS83
+Panasonic,PV-L2000
+Panasonic,PV-L2001
+Panasonic,PV-SD4090
+Panasonic,PV-SD5000
+Panasonic,SDR-H100
+Panasonic,SDR-H18
+Panasonic,SDR-H20
+Panasonic,SDR-H21
+Panasonic,SDR-H250
+Panasonic,SDR-H280
+Panasonic,SDR-H40
+Panasonic,SDR-H41
+Panasonic,SDR-H50
+Panasonic,SDR-H60
+Panasonic,SDR-H80
+Panasonic,SDR-H81
+Panasonic,SDR-H85
+Panasonic,SDR-H90
+Panasonic,SDR-H91
+Panasonic,SDR-H95
+Panasonic,SDR-S10
+Panasonic,SDR-S100
+Panasonic,SDR-S15
+Panasonic,SDR-S150
+Panasonic,SDR-S200
+Panasonic,SDR-S26
+Panasonic,SDR-S45
+Panasonic,SDR-S50
+Panasonic,SDR-S7
+Panasonic,SDR-S70
+Panasonic,SDR-S9
+Panasonic,SDR-SW20
+Panasonic,SDR-SW21
+Panasonic,SDR-T50
+Panasonic,SV-AS10
+Panasonic,SV-AS3
+Panasonic,SV-AS30
+Panasonic,SV-AV10
+Panasonic,SV-AV100
+Panasonic,SV-AV20
+Panasonic,SV-AV25
+Panasonic,SV-AV30
+Panasonic,SV-AV35
+Panasonic,SV-AV50
+Panasonic,VDR-D150
+Panasonic,VDR-D160
+Panasonic,VDR-D200
+Panasonic,VDR-D220
+Panasonic,VDR-D230
+Panasonic,VDR-D250
+Panasonic,VDR-D300
+Panasonic,VDR-D310
+Panasonic,VDR-D50
+Panasonic,VDR-D51
+Panasonic,VDR-M30
+Panasonic,VDR-M50
+Panasonic,VDR-M53
+Panasonic,VDR-M70
+Panasonic,X700
+Panasonic,ipalm
+PANTECH,IM-R300
+PANTECH,IM-S200K
+PANTECH,IM-S230
+PANTECH,IM-S250L
+PANTECH,IM-S340L
+PANTECH,IM-S370
+PANTECH,IM-U220
+PANTECH,IM-U220K
+PANTECH,IM-U300K
+Pantech,PG-3500
+Pantech,PG-3600
+Pantech,PG-6200
+Pantech,PG-8000
+"Pantech Wireless, Inc",PR-600
+PARROT,Bebop Drone
+PENTACON,DC60
+PENTACON,DCZ 5.5
+PENTACON,DCZ 5.8
+PENTACON,DCZ 6.8
+PENTACON,DCZ 7.1
+PENTACON,DCZ 7.4
+Pentacon,DCZ  8.1
+PENTACON,DCZ 8.2
+PENTACON,DCZ 8.3
+PENTACON,DPIX 540Z
+PENTACON,DPix 530Z
+PENTACON,DPix 740Z
+PENTACON,DPix 750Z
+Pentacon,Dpix 820Z
+PENTACON,LM 10-XS
+Pentacon,LM 6105
+Pentacon,LM 6403
+PENTACON,LM 7303
+PENTACON,LM 8003
+PENTACON,LM 8203
+PENTACON,LM 8303
+PENTACON,LM 8503
+PENTACON,LM10-X3
+Pentacon,Luxmedia 6503
+Pentacon,Luxmedia 7203
+PENTACON,Luxmedia 8403
+PENTACON,PENTACON DCZ 12.1
+PENTACON,PENTACON Dpix 1100Z
+Pentacon,PRAKTICA LM7403
+Pentacon,Praktica DVC 5.4 HDMI
+PENTACON GERMANY,luxmedia 7103
+PENTAX,PENTAX 645D
+PENTAX,PENTAX EI-200 (V1.10)
+PENTAX,PENTAX EI-2000 (V01.00)
+PENTAX Corporation,IQ Digital 59e
+PENTAX,PENTAX K-01
+PENTAX,PENTAX K-30
+PENTAX,PENTAX K-5
+PENTAX,PENTAX K-5 II
+PENTAX,PENTAX K-5 II s
+PENTAX,PENTAX K-50
+PENTAX,PENTAX K-500
+PENTAX,PENTAX K-7
+PENTAX,PENTAX K-m
+PENTAX,PENTAX K-r
+PENTAX,PENTAX K-x
+PENTAX Corporation,PENTAX K100D
+PENTAX Corporation,PENTAX K100D Super
+PENTAX Corporation,PENTAX K10D
+PENTAX Corporation,PENTAX K110D
+PENTAX,PENTAX K2000
+PENTAX Corporation,PENTAX K200D
+PENTAX Corporation,PENTAX K20D
+PENTAX Corporation,PENTAX Optio 30
+PENTAX Corporation,PENTAX Optio 330GS
+PENTAX Corporation,PENTAX Optio 33L
+PENTAX Corporation,PENTAX Optio 33LF
+PENTAX Corporation,PENTAX Optio 33WR
+PENTAX Corporation,PENTAX Optio 43WR
+PENTAX Corporation,PENTAX Optio 450
+PENTAX Corporation,PENTAX Optio 50
+PENTAX Corporation,PENTAX Optio 50L
+PENTAX Corporation,PENTAX Optio 550
+PENTAX Corporation,PENTAX Optio 555
+PENTAX Corporation,PENTAX Optio 60
+PENTAX Corporation,PENTAX Optio 750Z
+PENTAX Corporation,PENTAX Optio A10
+PENTAX Corporation,PENTAX Optio A20
+PENTAX Corporation,PENTAX Optio A30
+PENTAX Corporation,PENTAX Optio A40
+PENTAX Corporation,PENTAX Optio E10
+PENTAX Corporation,PENTAX Optio E30
+PENTAX Corporation,PENTAX Optio E35
+PENTAX Corporation,PENTAX Optio E40
+PENTAX Corporation,PENTAX Optio E50
+PENTAX,PENTAX Optio E60
+PENTAX,Optio E65
+PENTAX,PENTAX Optio E70
+PENTAX,Optio E70L
+PENTAX,Optio E75
+PENTAX,PENTAX Optio E80
+PENTAX,Optio E85
+PENTAX,PENTAX Optio E90
+PENTAX,PENTAX Optio H90
+PENTAX,PENTAX Optio I-10
+PENTAX Corporation,PENTAX Optio L20
+PENTAX Corporation,PENTAX Optio L30
+PENTAX Corporation,PENTAX Optio L36
+PENTAX Corporation,PENTAX Optio L40
+PENTAX Corporation,PENTAX Optio L50
+PENTAX,PENTAX Optio L70
+PENTAX,PENTAX Optio LS1000
+PENTAX,PENTAX Optio LS465
+PENTAX Corporation,PENTAX Optio M10
+PENTAX Corporation,PENTAX Optio M20
+PENTAX Corporation,PENTAX Optio M30
+PENTAX Corporation,PENTAX Optio M40
+PENTAX Corporation,PENTAX Optio M50
+PENTAX,PENTAX Optio M60
+PENTAX,Optio M85
+PENTAX,PENTAX Optio M90
+PENTAX Corporation,PENTAX Optio MX
+PENTAX Corporation,PENTAX Optio MX4
+PENTAX,PENTAX Optio NB1000
+PENTAX,PENTAX Optio P70
+PENTAX,PENTAX Optio P80
+PENTAX,PENTAX Optio RS1000
+PENTAX,PENTAX Optio RS1500
+PENTAX,PENTAX Optio RZ10
+PENTAX,PENTAX Optio RZ18
+PENTAX Corporation,PENTAX Optio S
+PENTAX,PENTAX Optio S1
+PENTAX Corporation,PENTAX Optio S10
+PENTAX Corporation,PENTAX Optio S12
+PENTAX Corporation,PENTAX Optio S30
+PENTAX Corporation,PENTAX Optio S4
+PENTAX Corporation,PENTAX Optio S40
+PENTAX Corporation,PENTAX Optio S45
+PENTAX Corporation,PENTAX Optio S4i
+PENTAX Corporation,PENTAX Optio S50
+PENTAX Corporation,PENTAX Optio S55
+PENTAX Corporation,PENTAX Optio S5i
+PENTAX Corporation,PENTAX Optio S5n
+PENTAX Corporation,PENTAX Optio S5z
+PENTAX Corporation,PENTAX Optio S6
+PENTAX Corporation,PENTAX Optio S60
+PENTAX Corporation,PENTAX Optio S7
+PENTAX Corporation,PENTAX Optio SV
+PENTAX Corporation,PENTAX Optio SVi
+PENTAX Corporation,PENTAX Optio T10
+PENTAX Corporation,PENTAX Optio T20
+PENTAX Corporation,PENTAX Optio T30
+PENTAX Corporation,PENTAX Optio V10
+PENTAX,PENTAX Optio V20
+PENTAX,PENTAX Optio VS20
+PENTAX Corporation,PENTAX Optio W10
+PENTAX Corporation,PENTAX Optio W20
+PENTAX Corporation,PENTAX Optio W30
+PENTAX,PENTAX Optio W60
+PENTAX,PENTAX Optio W80
+PENTAX,PENTAX Optio W90
+PENTAX,PENTAX Optio WG-1 GPS
+PENTAX,PENTAX Optio WG-2 GPS
+PENTAX Corporation,PENTAX Optio WP
+PENTAX Corporation,PENTAX Optio WPi
+PENTAX,PENTAX Optio WS80
+PENTAX Corporation,PENTAX Optio X
+PENTAX Corporation,PENTAX Optio Z10
+PENTAX Corporation,PENTAX OptioE20
+PENTAX Corporation,PENTAX OptioE25
+PENTAX,PENTAX Q
+PENTAX,PENTAX Q-S1
+PENTAX,PENTAX Q10
+PENTAX,PENTAX Q7
+PENTAX,PENTAX X-5
+PENTAX,PENTAX X70
+PENTAX,PENTAX X90
+PENTAX Corporation,PENTAX *ist D
+PENTAX Corporation,PENTAX *ist DL
+PENTAX Corporation,PENTAX *ist DL2
+PENTAX Corporation,PENTAX *ist DS
+PENTAX Corporation,PENTAX *ist DS2
+PIONEER,DC1310
+Polaroid PDC 1050,
+made by Polaroid,6M Digital Camera
+Polaroid,A310
+Polaroid,A330
+Polaroid,A500C
+Polaroid,Polaroid CUBE
+Polaroid,Polaroid DSC t830
+Polaroid,ION 230
+POLAROID,Model a500
+Polaroid,Model a500
+Polaroid,Model a530
+POLAROID,P4055
+POLAROID,P5055
+POLAROID,PDC 3080
+Polaroid, PDC 5350
+Polaroid PDC 6350,Polaroid PDC 6350
+Polaroid,PDC1075
+Polaroid,PDC1300
+POLAROID,PDC1320
+Polaroid,PDC2300Z
+Polaroid,PDC4355
+POLAROID,PDC5070
+POLAROID,PDC5070 CMOS
+POLAROID,PDC5080
+Polaroid,PDC5355
+Polaroid,Speed star i835
+Polaroid,Z340
+Polaroid,a530 Digital Camera
+Polaroid,Polaroid a930
+Polaroid,Polaroid a932
+Polaroid,i1035
+Polaroid,i1037
+Polaroid,i1237
+Polaroid,i531
+Polaroid,Polaroid i532
+Polaroid,i533
+Polaroid,i630
+Polaroid,i639
+Polaroid,i733
+Polaroid,i737
+made by Polaroid,Polaroid i830 DSD
+Polaroid,Polaroid i832
+Polaroid,i834
+Polaroid,i836
+Polaroid,izone300
+Polaroid,izone550
+Polaroid,t1031
+Polaroid,t1035
+Polaroid,t1234
+Polaroid,x530
+Polaroid,PolaroidPDC4350
+PRAKTICA,DVC 10.1 HDMI
+PRAKTICA,Dpix 5000WP
+PRAKTICA,LM 5003
+Prometheus,BTC-6PXD
+Prometheus,BTC5HDP
+Q6065BSNAXHZ33504,Samsung SCH-U440
+Q6065BSNAXHZ33504,Samsung SCH-U650
+RED,H1A1000
+Research In Motion,BlackBerry 8100
+Research In Motion,BlackBerry 8110
+Research In Motion,BlackBerry 8120
+Research In Motion,BlackBerry 8130
+Research In Motion,BlackBerry 8220
+Research In Motion,BlackBerry 8300
+Research In Motion,BlackBerry 8310
+Research In Motion,BlackBerry 8320
+Research In Motion,BlackBerry 8330
+Research In Motion,BlackBerry 8520
+Research In Motion,BlackBerry 8530
+Research In Motion,BlackBerry 8900
+Research In Motion,BlackBerry 9000
+Research In Motion,BlackBerry 9100
+Research In Motion,BlackBerry 9105
+Research In Motion,BlackBerry 9300
+Research In Motion,BlackBerry 9500
+Research In Motion,BlackBerry 9520
+Research In Motion,BlackBerry 9550
+Research In Motion,BlackBerry 9650
+Research In Motion,BlackBerry 9700
+Research In Motion,BlackBerry 9800
+Research In Motion,Blackberry Z10
+RJD,LDC-828Z3
+RECONYX,HC550 HYPERFIRE
+RECONYX,HC600 HYPERFIRE
+RECONYX,HF2 PRO COVERT
+RECONYX,HYPERFIRE HP4K
+RECONYX,MS7 SECURITY
+RECONYX,PC800 PROFESSIONAL
+RECONYX,PC850 PROFESSIONAL
+Reconyx,PC90 COVERT PRO
+Reconyx,RapidFire
+RECONYX,UltraFire
+RICOH,CX1
+RICOH,CX2
+RICOH,CX3
+RICOH,CX4
+RICOH,CX5
+RICOH,CX6
+RICOH,Caplio
+RICOH,Caplio 300G
+RICOH,Caplio 500SE
+RICOH,Caplio G4
+RICOH,Caplio G4 wide
+RICOH,Caplio GX
+RICOH,Caplio GX100
+RICOH,Caplio GX8
+RICOH,Caplio Pro G3
+RICOH,Caplio R1
+RICOH,Caplio R1S
+RICOH,Caplio R1V
+RICOH,Caplio R2
+RICOH,Caplio R2S
+RICOH,Caplio R3
+RICOH,Caplio R30
+RICOH,Caplio R4
+RICOH,Caplio R40
+RICOH,Caplio R5
+RICOH,Caplio R6
+RICOH,Caplio R7
+RICOH,Caplio RR1
+RICOH,Caplio RR10
+RICOH,Caplio RR120
+RICOH,Caplio RR211
+RICOH,Caplio RR230
+RICOH,Caplio RR30
+RICOH,Caplio RR430
+RICOH,Caplio RR530
+Ricoh,Caplio RR630
+RICOH,Caplio RR770
+RICOH,Caplio RX
+RICOH,Caplio RZ1
+RICOH,Caplio400Gwide
+RICOH,Caplio500Gwide
+RICOH,CaplioG3 modelM
+RICOH,CaplioG3 modelS
+RICOH,DC-3
+RICOH,DC-3Z
+RICOH,DC-4
+RICOH,DC-4T
+RICOH,DC-4U
+RICOH,G600
+RICOH,G700
+RICOH,G700 SE
+RICOH,G800
+PENTAX RICOH IMAGING,GR
+RICOH,GR Digital
+RICOH,GR DIGITAL 2
+RICOH,GR DIGITAL 3
+RICOH,GR DIGITAL 4
+"RICOH IMAGING COMPANY, LTD.",GR II
+RICOH,GXR
+RICOH,GXR A12
+RICOH,GXR A16
+RICOH,GXR MOUNT A12
+RICOH,GXR P10
+"RICOH IMAGING COMPANY, LTD.",PENTAX 645Z
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-1
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-1 Mark II
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-3
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-3 II
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-3 Mark III
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-70
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-S1
+"RICOH IMAGING COMPANY, LTD.",PENTAX K-S2
+"RICOH IMAGING COMPANY, LTD.",PENTAX KF
+"RICOH IMAGING COMPANY, LTD.",PENTAX KP
+PENTAX RICOH IMAGING,PENTAX MX-1
+PENTAX RICOH IMAGING,PENTAX WG-10
+PENTAX RICOH IMAGING,PENTAX WG-3
+PENTAX RICOH IMAGING,PENTAX WG-3 GPS
+"RICOH IMAGING COMPANY, LTD.",PENTAX XG-1
+RICOH,PX
+RICOH,RDC-200G
+RICOH,RDC-5000
+RICOH,RDC-5300
+RICOH,RDC-6000
+RICOH,RDC-7
+RICOH,RDC-7S
+RICOH,RDC-i500
+RICOH,RDC-i700
+RICOH,RDXIFW32
+RICOH,RICOH G900SE
+"RICOH IMAGING COMPANY, LTD.",RICOH GR III
+"RICOH IMAGING COMPANY, LTD.",RICOH GR IIIx
+RICOH,RICOH GX200
+RICOH IMAGING,RICOH HZ15
+RICOH,RICOH R10
+RICOH,RICOH R50
+RICOH,RICOH R8
+RICOH,RICOH THETA
+RICOH,RICOH THETA S
+RICOH,RICOH THETA V
+RICOH,RICOH THETA m15
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-20
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-30
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-30W
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-4
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-4 GPS
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-5 GPS
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-50
+RICOH,RICOH WG-6
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-60
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-70
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-M1
+"RICOH IMAGING COMPANY, LTD.",RICOH WG-M2
+RICOH,RICOH THETA SC2
+Rollei,D330
+Rollei Fototechnic GmbH,D41COM
+ROLLEI,RCP CL200
+ROLLEI,RCP CL350
+Rollei,RCP-10325X
+Rollei,RCP-5324
+ROLLEI,RCP-6324
+ROLLEI,RCP-7324
+ROLLEI,RCP-7325XS
+ROLLEI,RCP-7330X
+ROLLEI,RCP-7430XW
+Rollei,RCP-8325X
+         Rollei, Rollei XS-8
+ROLLEI,da6325
+Rollei,dk4010
+Rollei,dr5
+ROLLEI,dsx410
+ROLLEI,Compactline 202
+SAGEM,VF527
+SAGEM,my401C
+SAGEM,my411C
+SAGEM,my411V
+SAGEM,my411X
+SAGEM,my501X
+SAGEM,my511X
+SAGEM,my700x
+SAGEM,my730C
+SAGEM,my750X
+SAGEM,my850C
+SAGEM,myMovieBox
+SAGEM,myX-8
+SAGEM,myX6-2
+SEALIFE,SEALIFE DC2000
+SEMC,X10i
+SK Teletech,IM-8100
+SKY?ڷ??آ?,IM-U110
+SKY?ڷ??آ?,IM-U140
+"SUNPLUS TECHNOLOGY CO.,  LTD.",SPCA536
+Samsung,707SC
+Samsung,707SCII
+Samsung,709SC
+Samsung Electronics,730SC
+Samsung Electronics,A707
+Samsung Electronics,A767
+SAMSUNG Electronics,Anycall SCH-B500
+SAMSUNG Electronics,Anycall SCH-B540
+SAMSUNG Electronics,Anycall SCH-B660
+SAMSUNG Electronics,Anycall SCH-S470
+SAMSUNG Electronics,Anycall SCH-S510
+SAMSUNG Electronics,Anycall SCH-V900
+SAMSUNG Electronics,Anycall SCH-V940
+SAMSUNG Electronics,Anycall SCH-W240
+SAMSUNG Electronics,Anycall SCH-W270
+SAMSUNG Electronics,Anycall SCH-W330
+SAMSUNG Electronics,Anycall SCH-W390
+SAMSUNG Electronics,Anycall SCH-W410
+SAMSUNG Electronics,Anycall SCH-W460
+SAMSUNG Electronics,Anycall SCH-W5500
+SAMSUNG Electronics,Anycall SCH-W579
+SAMSUNG Electronics,Anycall SCH-W720
+SAMSUNG Electronics,Anycall SCH-W750
+SAMSUNG Electronics,Anycall SGH-i640
+SAMSUNG Electronics,Anycall SPH-A503
+SAMSUNG Electronics,Anycall SPH-B5650
+SAMSUNG Electronics,Anycall SPH-B6650
+SAMSUNG Electronics,Anycall SPH-B8850
+SAMSUNG Electronics,Anycall SPH-C2350
+SAMSUNG Electronics,Anycall SPH-C3250
+SAMSUNG Electronics,Anycall SPH-S4850
+SAMSUNG Electronics,Anycall SPH-V9000
+SAMSUNG Electronics,Anycall SPH-V9850
+SAMSUNG Electronics,Anycall SPH-W2500
+SAMSUNG Electronics,Anycall SPH-W2700
+SAMSUNG Electronics,Anycall SPH-W2900
+SAMSUNG Electronics,Anycall SPH-W3300
+SAMSUNG Electronics,Anycall SPH-W3500
+SAMSUNG Electronics,Anycall SPH-W4100
+SAMSUNG Electronics,Anycall SPH-W4450
+SAMSUNG,SAMSUNG B2100
+Samsung Electronics,B2300
+SAMSUNG,B5702
+"Samsung Electronics Co., Ltd.",C3050
+"Samsung Electronics Co., Ltd.",C3053
+SAMSUNG,C5212
+SAMSUNG,D250 DigitalCAM
+Samsung Techwin,<Samsung D70 / D75 / S730 / S750>
+Samsung Techwin,<Samsung D75>
+SAMSUNG TECHWIN,DIGIMAX 130
+SAMSUNG,DIGIMAX 350SE
+"SAMSUNG TECHWIN CO,LTD",DIGIMAX-230
+"SAMSUNG TECHWIN CO,LTD",DIGIMAX-340
+"SAMSUNG TECHWIN CO,LTD",DIGIMAX-410
+SAMSUNG,DV150F/DV151F/DV155F
+SAMSUNG,DV300 / DV300F / DV305F
+SAMSUNG ELECTRONICS,SAMSUNG DVC
+,Digimax101
+Samsung,Digimax 200
+Samsung,Digimax 201
+Samsung,Digimax 202
+Samsung Corporation,Digimax 210SE
+Samsung Corporation,Digimax 220SE
+Samsung Techwin,Digimax 240
+Samsung,Digimax 300
+Samsung,Digimax 301
+"Samsung  OPTICAL CO,LTD",Samsung Digimax 330
+Samsung Techwin,Digimax 360
+"SAMSUNG TECHWIN CO., LTD",Digimax 370 / Kenox D370
+Samsung,Digimax 401
+Samsung Techwin,Digimax 420
+"SAMSUNG TECHWIN CO., LTD",Digimax 430 / Kenox D430
+Samsung Techwin,Digimax 530 / KENOX D530
+"Samsung Techwin co., Ltd.",Digimax A302
+"SAMSUNG TECHWIN CO., LTD.",Digimax A4/Kenox D4
+"SAMSUNG TECHWIN CO., LTD.",Digimax A40 / KENOX Q1
+Samsung Techwin,Digimax A400
+"Samsung Techwin co., Ltd.",Digimax A402
+"Samsung Techwin co., Ltd.",Digimax A403 / Kenox D403
+"SAMSUNG TECHWIN CO., LTD.",Digimax A5
+"SAMSUNG TECHWIN CO., LTD.",Digimax A50 / KENOX Q2
+"Samsung Techwin co., Ltd.",Digimax A502
+"Samsung Techwin co., Ltd.",Digimax A503 / Kenox D503
+"Samsung Techwin co., Ltd.",Digimax A55W / Kenox Q25 WIDE
+"SAMSUNG TECHWIN CO., LTD.",Digimax A6
+"SAMSUNG TECHWIN CO., LTD.",Digimax A7/Kenox D7
+Samsung Techwin,<Digimax D53>
+"SAMSUNG TECHWIN CO., LTD.",Digimax L40 / KENOX X1
+"SAMSUNG TECHWIN CO., LTD.",Digimax L50 / KENOX X1
+Samsung Techwin,Digimax L55W / Kenox X15 WIDE
+"SAMSUNG TECHWIN CO., LTD.",Digimax L60
+"SAMSUNG TECHWIN CO., LTD.",Digimax L70/Kenox X70
+Samsung Techwin,<Digimax L80 / Kenox X80>
+"SAMSUNG TECHWIN CO., LTD.",Digimax L85
+Samsung Techwin,<Digimax S1000 / Kenox S1000>
+Samsung Techwin,<Digimax S1030 / Kenox S1030>
+Samsung Techwin,<Digimax S500 / Kenox S500 / Digimax Cyber 530>
+Samsung Techwin,<Digimax S600 / Kenox S600 / Digimax Cyber 630>
+Samsung Techwin,<Digimax S700 / Kenox S700 / Digimax Cyber 730>
+Samsung Techwin,<Digimax S800 / Kenox S800>
+Samsung Techwin,<Digimax S830 / Kenox S830>
+"SAMSUNG TECHWIN CO,. LTD","Digimax U-CA 401/ Kenox ME4, CD4"
+Samsung Techwin,"< Digimax U-CA 5, Kenox U-CA 5 / Kenox U-CA 50 >"
+Samsung Techwin,Digimax V3
+Samsung Techwin,Digimax V4
+"SAMSUNG TECHWIN CO., LTD",Digimax V5 / Kenox V5
+Samsung Techwin,Digimax V50/a5
+"SAMSUNG TECHWIN CO., LTD",Digimax V6 / Kenox V6
+Samsung Techwin,Digimax V70/a7
+Samsung Techwin,<Digimax V700 / Kenox V10 / Digimax V10 >
+Samsung Techwin,<Digimax V800 / Kenox V20 / Digimax V20 >
+SAMSUNG,SAMSUNG-EK-GC100
+SAMSUNG,EK-GC200
+SAMSUNG,EK-GN120
+SAMSUNG,SAMSUNG ES10 / VLUU ES10
+SAMSUNG,SAMSUNG ES15 / VLUU ES15 / SAMSUNG SL30
+SAMSUNG,SAMSUNG ES17 / VLUU ES17 / SAMSUNG SL40 / SAMSUNG ES19
+SAMSUNG,"SAMSUNG ES25, ES27 / VLUU ES25, ES27 / SAMSUNG SL45"
+SAMSUNG,SAMSUNG ES28 / VLUU ES28
+SAMSUNG,SAMSUNG ES30/VLUU ES30
+SAMSUNG,"SAMSUNG ES55,ES57 / VLUU ES55 / SAMSUNG SL102"
+SAMSUNG,"SAMSUNG ES65, ES67 / VLUU ES65, ES67 / SAMSUNG SL50"
+SAMSUNG,SAMSUNG ES68
+SAMSUNG,"SAMSUNG ES70, ES71 / VLUU ES70, ES71 / SAMSUNG SL600"
+SAMSUNG,SAMSUNG ES73 / VLUU ES73 / SAMSUNG SL605
+SAMSUNG,"SAMSUNG ES74,ES75,ES78 / VLUU ES75,ES78"
+SAMSUNG,SAMSUNG ES80/SAMSUNG ES81
+SAMSUNG,SAMSUNG ES9/SAMSUNG ES8
+SAMSUNG,ES95
+SAMSUNG,EX1
+SAMSUNG,EX2F
+Samsung Electronics,F400
+Samsung Electronics,FM-1
+Samsung Electronics,G800
+SAMSUNG,GT-B2710
+SAMSUNG,GT-B3210
+SAMSUNG,GT-B3310
+SAMSUNG,GT-B3410
+Samsung,GT-B3410W
+Samsung,GT-B5310
+SAMSUNG,GT-B5722
+SAMSUNG,GT-B7300
+SAMSUNG Electronics,GT-B7320
+SAMSUNG,GT-B7350
+SAMSUNG,GT-B7610
+SAMSUNG,GT-B7620
+SAMSUNG,GT-B7722
+"Samsung Electronics Co., Ltd.",GT-C3010
+Samsung Electronics,GT-C3110
+SAMSUNG,GT-C3200
+SAMSUNG,GT-C3212
+SAMSUNG,GT-C3222
+SAMSUNG,GT-C3300K
+SAMSUNG,SAMSUNG GT-C3510
+SAMSUNG,GT-C3530
+SAMSUNG,GT-C5510
+SAMSUNG,GT-C6112
+SAMSUNG,GT-E2100
+SAMSUNG,GT-E2121B
+SAMSUNG,GT-E2152
+SAMSUNG,GT-E2210
+SAMSUNG,GT-E2370
+SAMSUNG ELEC.,GT-E2510
+SAMSUNG,GT-E2530
+SAMSUNG,GT-E2550
+SAMSUNG,GT-E2652
+SAMSUNG,GT-E2652W
+SAMSUNG,GT-E3210
+SAMSUNG,GT-I5500
+SAMSUNG,GT-I5800
+SAMSUNG,GT-I8000
+SAMSUNG,GT-I8190
+SAMSUNG,GT-I8200L
+SAMSUNG,GT-I8552B
+SAMSUNG,GT-I8700
+SAMSUNG,GT-I9000
+SAMSUNG,GT-I9000M
+SAMSUNG,GT-I9003
+SAMSUNG, GT-I9008
+samsung,GT-I9060I
+SAMSUNG,GT-I9070
+SAMSUNG,GT-I9082
+Samsung,GT-I9100
+SAMSUNG,GT-I9192
+SAMSUNG,GT-I9195
+SAMSUNG,GT-I9205
+SAMSUNG,GT-I9295
+SAMSUNG,GT-I9300
+SAMSUNG,GT-I9301I
+SAMSUNG,GT-I9500
+SAMSUNG,GT-I9505
+SAMSUNG,GT-M3310
+Samsung,GT-M3710
+SAMSUNG,GT-M8800
+SAMSUNG,GT-M8800H
+SAMSUNG,GT-M8910
+SAMSUNG,GT-N7000
+SAMSUNG,GT-N7100
+Samsung Electronics,GT-S3030
+SAMSUNG,GT-S3100
+Samsung,GT-S3310
+SAMSUNG,GT-S3350
+SAMSUNG,GT-S3370
+Samsung Electronics,GT-S3500
+SAMSUNG,GT-S3550
+Samsung,GT-S3650
+SAMSUNG,GT-S3850
+SAMSUNG,GT-S5150
+Samsung,GT-S5230
+Samsung,GT-S5233T
+SAMSUNG,GT-S5250
+SAMSUNG,GT-S5260
+SAMSUNG,GT-S5330
+SAMSUNG,GT-S5350
+SAMSUNG,GT-S5510
+SAMSUNG,GT-S5550
+Samsung,GT-S5560
+SAMSUNG,GT-S5570
+SAMSUNG,GT-S5600
+SAMSUNG,GT-S5620
+SAMSUNG,GT-S5660
+SAMSUNG,GT-S5670
+SAMSUNG,GT-S5830
+Samsung,GT-S7070
+SAMSUNG,GT-S7550
+SAMSUNG,GT-S8000
+SAMSUNG,GT-S8500
+SAMSUNG,GT-S8530
+SAMSUNG,GT-S9402
+SAMSUNG,GT-i5700
+SAMSUNG,GT-i7500
+SAMSUNG,GT-i8910
+Samsung Techwin,Samsung GX-1L
+Samsung Techwin,Samsung GX-1S
+SAMSUNG TECHWIN Co.,SAMSUNG GX10
+SAMSUNG TECHWIN Co.,SAMSUNG GX20
+samsung,Galaxy A15
+samsung,Galaxy A55 5G
+Samsung,Galaxy Nexus
+samsung,Galaxy S23 Ultra
+SAMSUNG,HMX-E10
+SAMSUNG,HMX-H300
+SAMSUNG,HMX-H304
+Samsung Electronics,HMX-M20
+SAMSUNG,HMX-Q10
+Samsung Electronics,HMX-R10
+SAMSUNG,HMX-S10BP
+SAMSUNG,HMX-S15BP
+SAMSUNG,HMX-U10
+Samsung Electronics,HMX-U20
+SAMSUNG,SAMSUNG I7110
+SAMSUNG,SAMSUNG I8510
+SAMSUNG,SAMSUNG IT100 / VLUU IT100 / SAMSUNG SL820
+SAMSUNG,J700E
+SAMSUNG,J770
+Samsung Techwin,KENOX X77 / L77 Digital Camera
+"SAMSUNG TECHWIN CO., LTD.",Samsung L201
+"SAMSUNG TECHWIN CO., LTD.",Samsung L600
+"SAMSUNG TECHWIN CO., LTD.",Samsung L700
+"SAMSUNG TECHWIN CO., LTD.",Samsung L73
+Samsung Techwin,"<Samsung L74, Samsung VLUU L74>"
+Samsung Electronics,L760
+Samsung Electronics,L768
+SAMSUNG,SAMSUNG M3510
+Samsung Electronics,M7600
+SAMSUNG ELECTRONICS,MINIKET
+SAMSUNG ELECTRONICS,MINIKET MEGA
+SAMSUNG,SAMSUNG MV800
+SAMSUNG,SAMSUNG MV900F
+SAMSUNG TECHWIN,"NV100HD, VLUU NV100HD, LANDIAO NV100HD, TL34HD"
+SAMSUNG TECHWIN,"NV11, VLUU NV11"
+SAMSUNG TECHWIN,"NV15, VLUU NV15"
+SAMSUNG TECHWIN,"NV20, VLUU NV20"
+SAMSUNG TECHWIN,"NV24HD, VLUU NV24HD, LANDIAO NV106HD"
+Samsung Techwin,"<Samsung NV3, Samsung VLUU NV3>"
+SAMSUNG TECHWIN,"NV30, VLUU NV30, LANDIAO NV30"
+Samsung Techwin,"<Samsung NV4, Samsung VLUU NV4>"
+SAMSUNG TECHWIN,"NV40, VLUU NV40, LANDIAO NV103, VLUU NV404"
+SAMSUNG TECHWIN,NV5 / VLUU NV5
+SAMSUNG TECHWIN,"NV8 , VLUU NV8"
+Samsung Techwin,"<Samsung NV9, Samsung VLUU NV9>"
+SAMSUNG,NX mini
+SAMSUNG,NX1
+SAMSUNG,NX10
+SAMSUNG,NX100
+SAMSUNG,NX1000
+SAMSUNG,NX11
+SAMSUNG,NX1100
+SAMSUNG,NX20
+SAMSUNG,NX200
+SAMSUNG,NX2000
+SAMSUNG,NX210
+SAMSUNG,NX30
+SAMSUNG,NX300
+SAMSUNG,NX3000
+SAMSUNG,NX3300
+SAMSUNG,NX5
+SAMSUNG,NX500
+Samsung Electronics,P940
+SAMSUNG,SAMSUNG PL10 / VLUU PL10 / SAMSUNG CL5
+SAMSUNG,SAMSUNG PL100 / SAMSUNG TL205 / VLUU PL100 / SAMSUNG PL101
+SAMSUNG,"SAMSUNG PL120,PL121 / VLUU PL120,PL121"
+SAMSUNG,SAMSUNG PL150 / VLUU PL150 / SAMSUNG TL210 / SAMSUNG PL151
+SAMSUNG,"SAMSUNG PL170,PL171 / VLUUPL170,PL171"
+SAMSUNG,SAMSUNG PL200/VLUU PL200
+SAMSUNG,"SAMSUNG PL20,PL21 / VLUU PL20,PL21"
+SAMSUNG,"SAMSUNG PL210, PL211 / VLUU PL210, PL211"
+SAMSUNG,SAMSUNG PL221
+SAMSUNG,SAMSUNG PL50 / VLUU PL50 / SAMSUNG SL202
+SAMSUNG,SAMSUNG PL51 / VLUU PL51 / SAMSUNG SL203
+SAMSUNG,SAMSUNG PL55/ VLUU PL55/ SAMSUNG SL502/ SAMSUNG PL57
+SAMSUNG,SAMSUNG PL60 / VLUU PL60 / SAMSUNG SL420
+SAMSUNG,SAMSUNG PL70 / VLUU PL70 / SAMSUNG SL720
+SAMSUNG,SAMSUNG PL80/VLUU PL80/SAMSUNG SL630/SAMSUNG PL81
+SAMSUNG,SAMSUNG PL90/VLUU PL90
+SAMSUNG TECHWIN,Pro 815
+"SAMSUNG TECHWIN CO., LTD.",Samsung S1060
+"SAMSUNG TECHWIN CO., LTD.",Samsung S1065
+"SAMSUNG TECHWIN CO., LTD.",Samsung S1070 / KENOX S1070
+SAMSUNG,S3600
+SAMSUNG,SAMSUNG S5050
+SAMSUNG,SAMSUNG S5200
+Samsung,S5230
+Samsung Electronics,S5600
+Samsung Electronics,S7220
+Samsung Electronics,S7350
+Samsung Electronics,S8300
+"SAMSUNG TECHWIN CO., LTD.",Samsung S85
+"SAMSUNG TECHWIN CO., LTD.",Samsung S850
+SAMSUNG ELECTRONICS,SC-D230
+SAMSUNG ELECTRONICS,SC-D353
+SAMSUNG ELECTRONICS,SC-D354
+SAMSUNG ELECTRONICS,SC-D453
+SAMSUNG ELECTRONICS,SC-D6550
+SAMSUNG ELECTRONICS,SC-DC173U
+SAMSUNG ELECTRONICS,SCD107
+SAMSUNG ELECTRONICS,SCD23
+SAMSUNG ELECTRONICS,SCD27
+SAMSUNG ELECTRONICS,SCD5000
+SAMSUNG ELECTRONICS,SCD6040
+SAMSUNG,SCH-A815
+SAMSUNG,SCH-A970
+SAMSUNG,SCH-B300
+SAMSUNG,SCH-B340
+SAMSUNG,SCH-B360
+SAMSUNG,SCH-B490
+SAMSUNG,SCH-E239
+SAMSUNG,SCH-G100
+SAMSUNG,SCH-I510
+SAMSUNG,SCH-I535
+SAMSUNG,SCH-S380
+SAMSUNG,SCH-S390
+SAMSUNG,SCH-U350
+Samsung,SCH-U540
+SAMSUNG,SCH-U620
+Samsung,SCH-V490
+SAMSUNG,SCH-V650
+SAMSUNG,SCH-V720
+SAMSUNG,SCH-V730
+SAMSUNG,SCH-V740
+SAMSUNG,SCH-V870
+SAMSUNG,SCH-V890
+"Samsung electronics Co.,Ltd.",SDC-130Z
+"Samsung electronics Co.,Ltd.",SDC-200Z
+SAMSUNG ELECTRONICS,SDC-K50
+SAMSUNG ELECTRONICS,SDC-K60B
+SAMSUNG ELECTRONICS,SDC-K60R
+SAMSUNG ELECTRONICS,SDC-K60S
+SAMSUNG ELECTRONICS,SDC-K65/DMB
+SAMSUNG ELECTRONICS,SDC-MS61B
+SAMSUNG,SGH G810
+Samsung Electronics,SGH-A736
+Samsung Electronics,SGH-A737
+Samsung,SGH-B2700
+SAMSUNG,SGH-D780
+SAMSUNG,SGH-D880
+SAMSUNG,SGH-D980
+SAMSUNG,SGH-E200
+SAMSUNG,SGH-E200B
+SAMSUNG,SGH-E2120
+SAMSUNG,SGH-E250
+SAMSUNG,SGH-E250B
+SAMSUNG,SGH-E258
+SAMSUNG,SGH-E260
+SAMSUNG,SGH-E380
+SAMSUNG,SGH-E390
+SAMSUNG,SGH-E480
+SAMSUNG,SGH-E500
+SAMSUNG,SGH-E780
+SAMSUNG,SGH-E830
+SAMSUNG,SGH-F110
+SAMSUNG,SGH-F250
+SAMSUNG,SGH-F250L
+SAMSUNG,SGH-F266
+Samsung Electronics,SGH-F330
+Samsung Electronics,SGH-F480
+Samsung Electronics,SGH-F488
+SAMSUNG,SGH-F488E
+SAMSUNG,SGH-F490
+SAMSUNG,SGH-F700
+SAMSUNG,SGH-F700V
+Samsung Electronics,SGH-G400
+SAMSUNG,SGH-G600
+SAMSUNG,SGH-G608
+SAMSUNG,SAMSUNG-SGH-I337
+Samsung,SGH-I620
+SAMSUNG,SGH-I747M
+SAMSUNG,SAMSUNG-SGH-I777
+SAMSUNG,SGH-I917
+SAMSUNG,SGH-J150
+Samsung Electronics,SGH-J200
+Samsung Electronics,SGH-J630
+SAMSUNG,SGH-J706
+SAMSUNG,SAMSUNG SGH-J770
+Samsung,SGH-J800
+Samsung Electronics,SGH-L170
+SAMSUNG,SGH-L310
+SAMSUNG,SGH-L600
+Samsung,SGH-L700
+Samsung Electronics,SGH-L770
+Samsung Electronics,SGH-L811
+SAMSUNG ELEC.,SGH-M150
+SAMSUNG,SGH-M200
+SAMSUNG,SGH-M610
+Samsung,SGH-P270
+SAMSUNG,SGH-T229
+SAMSUNG,SGH-T239
+SAMSUNG,SGH-T409
+SAMSUNG,SGH-T469
+Samsung Electronics,SGH-T559
+SAMSUNG,SGH-T659
+SAMSUNG,SGH-T729
+SAMSUNG,SGH-T739
+Samsung Electronics,SGH-T749
+Samsung Electronics,SGH-T819
+Samsung Electronics,SGH-T919
+SAMSUNG,SGH-T959
+SAMSUNG,SGH-T959V
+SAMSUNG,SGH-X700
+Samsung,SGH-i200
+SAMSUNG,SGH-i897
+SAMSUNG,SGH-i900
+SAMSUNG,SGH-i908
+SAMSUNG,Samsung SL201
+SAMSUNG,SAMSUNG SL620
+samsung,SM-A202F
+samsung,SM-A226B
+samsung,SM-A307FN
+samsung,SM-A600FN
+samsung,SM-A750FN
+samsung,SM-A805F
+SAMSUNG,SM-C101
+SAMSUNG,SAMSUNG-SM-C105A
+SAMSUNG,SM-C115
+SAMSUNG,SM-C200
+SAMSUNG,SM-E500H
+samsung,SM-F711N
+SAMSUNG,SM-G360F
+SAMSUNG,SM-G7102
+SAMSUNG,SM-G800F
+SAMSUNG,SM-G900F
+SAMSUNG,SM-G900V
+samsung,SM-G920F
+samsung,SM-G925F
+samsung,SM-G928F
+samsung,SM-G930F
+samsung,SM-G930P
+samsung,SM-G950F
+samsung,SM-G950U
+samsung,SM-G955W
+samsung,SM-G960F
+samsung,SM-G965F
+samsung,SM-G965U
+samsung,SM-G970F
+samsung,SM-G973F
+samsung,SM-G975F
+samsung,SM-G975U1
+samsung,SM-G986U1
+samsung,SM-G988B
+samsung,SM-G990U2
+samsung,SM-G998W
+samsung,SM-J510FN
+SAMSUNG,SM-N9005
+SAMSUNG,SM-N900T
+SAMSUNG,SM-N910G
+SAMSUNG,SM-N910V
+samsung,SM-N915G
+SAMSUNG,SM-N915T
+samsung,SM-N9208
+samsung,SM-N950F
+samsung,SM-N960F
+samsung,SM-N975X
+samsung,SM-N9860
+samsung,SM-N986B
+SAMSUNG,SM-R210
+SAMSUNG,SM-T705
+samsung,SM-T800
+SAMSUNG,SM-T805
+samsung,SM-T970
+SAMSUNG,SMX-C20N
+SAMSUNG ELECTRONICS,SMX-F30BP
+SAMSUNG ELECTRONICS,SMX-F34BN
+Samsung,SPH-A800
+Samsung,SPH-A940
+SAMSUNG,SPH-D700
+SAMSUNG,SPH-D710
+SAMSUNG,SPH-M520
+SAMSUNG,SPH-S1000
+SAMSUNG,SPH-S1450
+SAMSUNG Anycall,SPH-S2300
+SAMSUNG,SPH-S3900
+SAMSUNG,SPH-S4750
+SAMSUNG,SAMSUNG ST10 / VLUU ST10 / SAMSUNG CL50
+SAMSUNG,SAMSUNG ST1000 / SAMSUNG ST1100 / VLUU ST1000 / SAMSUNG CL65
+SAMSUNG,ST150F/ST151F/ST152F
+SAMSUNG,ST200 / ST200F / ST201 / ST201F / ST205F
+SAMSUNG,SAMSUNG ST30
+SAMSUNG,SAMSUNG ST45/ VLUU ST45/ SAMSUNG TL90
+SAMSUNG,SAMSUNG ST500 / VLUU ST500 / SAMSUNG TL220
+SAMSUNG,SAMSUNG ST550 / VLUU ST550 / SAMSUNG TL225
+SAMSUNG,SAMSUNG ST65 / VLUU ST65 / SAMSUNG ST67
+SAMSUNG,ST66 / ST68
+SAMSUNG,SAMSUNG ST70 / VLUU ST70 / SAMSUNG ST71
+SAMSUNG,ST700
+SAMSUNG,ST76 / ST78
+SAMSUNG,"SAMSUNG ST90,ST91 / VLUU ST90,ST91"
+SAMSUNG,SAMSUNG ST93
+SAMSUNG,SAMSUNG ST96
+Samsung Electronics,T639
+SAMSUNG,SAMSUNG TL100
+Samsung Techwin,U-CA 3 Digital Camera
+Samsung Techwin,U-CA 4 Digital Camera
+Samsung Techwin,U-CA 501
+Samsung Electronics,U700
+Samsung Electronics,U708
+Samsung Electronics,U800
+Samsung Electronics,U80F
+Samsung Electronics,U900
+SAMSUNG,V840
+Samsung Techwin,VLUU L77 / L77 Digital Camera
+SAMSUNG TECHWIN,"VLUU NV 7, NV 7"
+SAMSUNG TECHWIN,"VLUU NV10, NV10"
+SAMSUNG,"VLUU ST100, ST100"
+SAMSUNG,"VLUU ST5000, ST5000, TL240"
+SAMSUNG,"VLUU ST5500, ST5500, CL80"
+SAMSUNG,VLUU ST60
+SAMSUNG,"VLUU ST600, ST600"
+SAMSUNG,"VLUU ST80, ST80"
+SAMSUNG ELECTRONICS,VM-C5000
+SAMSUNG ELECTRONICS,VM-C730
+SAMSUNG ELECTRONICS,VM-C790
+SAMSUNG ELECTRONICS,VM-D7500B
+SAMSUNG ELECTRONICS,VM-D7500S
+SAMSUNG ELECTRONICS,VM-DC570
+SAMSUNG ELECTRONICS,VP-D103i
+SAMSUNG ELECTRONICS,VP-D105i
+SAMSUNG ELECTRONICS,VP-D107i
+SAMSUNG ELECTRONICS,VP-D23
+SAMSUNG ELECTRONICS,VP-D230
+SAMSUNG ELECTRONICS,VP-D24
+SAMSUNG ELECTRONICS,VP-D250
+SAMSUNG ELECTRONICS,VP-D323
+SAMSUNG ELECTRONICS,VP-D325
+SAMSUNG ELECTRONICS,VP-D33
+SAMSUNG ELECTRONICS,VP-D353
+SAMSUNG ELECTRONICS,VP-D353i
+SAMSUNG ELECTRONICS,VP-D354i
+SAMSUNG ELECTRONICS,VP-D355i
+SAMSUNG ELECTRONICS,VP-D363i
+SAMSUNG ELECTRONICS,VP-D364W
+SAMSUNG ELECTRONICS,VP-D364Wi
+SAMSUNG ELECTRONICS,VP-D365Wi
+SAMSUNG ELECTRONICS,VP-D375W
+SAMSUNG ELECTRONICS,VP-D375Wi
+SAMSUNG ELECTRONICS,VP-D39
+SAMSUNG ELECTRONICS,VP-D453
+SAMSUNG ELECTRONICS,VP-D453i
+SAMSUNG ELECTRONICS,VP-D454i
+SAMSUNG ELECTRONICS,VP-D455
+SAMSUNG ELECTRONICS,VP-D455i
+SAMSUNG ELECTRONICS,VP-D463
+SAMSUNG ELECTRONICS,VP-D463i
+SAMSUNG ELECTRONICS,VP-D5000i
+SAMSUNG ELECTRONICS,VP-D6040i
+SAMSUNG ELECTRONICS,VP-D6050
+SAMSUNG ELECTRONICS,VP-D6050i
+SAMSUNG ELECTRONICS,VP-D653
+SAMSUNG ELECTRONICS,VP-D653i
+SAMSUNG ELECTRONICS,VP-D655
+SAMSUNG ELECTRONICS,VP-D6550i
+SAMSUNG ELECTRONICS,VP-D655i
+SAMSUNG ELECTRONICS,VP-D73
+SAMSUNG ELECTRONICS,VP-D963
+SAMSUNG ELECTRONICS,VP-D963i
+SAMSUNG ELECTRONICS,VP-D964W
+SAMSUNG ELECTRONICS,VP-D964Wi
+SAMSUNG ELECTRONICS,VP-D975W
+SAMSUNG ELECTRONICS,VP-D975Wi
+SAMSUNG ELECTRONICS,VP-DC163
+SAMSUNG ELECTRONICS,VP-DC163i
+SAMSUNG ELECTRONICS,VP-DC165Wi
+SAMSUNG ELECTRONICS,VP-DC173
+SAMSUNG ELECTRONICS,VP-DC175WB
+SAMSUNG ELECTRONICS,VP-DC175Wi
+SAMSUNG ELECTRONICS,VP-DC563i
+SAMSUNG ELECTRONICS,VP-DC565W
+SAMSUNG ELECTRONICS,VP-DC565Wi
+SAMSUNG ELECTRONICS,VP-DC575WB
+SAMSUNG ELECTRONICS,VP-DC575Wi
+SAMSUNG ELECTRONICS,VP-DX103i
+SAMSUNG ELECTRONICS,VP-DX105i
+SAMSUNG ELECTRONICS,VP-DX205i
+SAMSUNG ELECTRONICS,VP-MS11
+SAMSUNG ELECTRONICS,VP-MS15
+SAMSUNG,WB100/ WB101
+SAMSUNG,SAMSUNG WB1000 / VLUU WB1000 / SAMSUNG TL320
+SAMSUNG,SAMSUNG WB1100F/WB1101F/WB1102F
+SAMSUNG,WB150 / WB150F / WB152 / WB152F / WB151
+SAMSUNG,WB2000
+SAMSUNG,WB200F/WB201F/WB202F
+SAMSUNG,SAMSUNG WB2100
+SAMSUNG,SAMSUNG WB2200F
+SAMSUNG,WB250F/WB251F/WB252F
+SAMSUNG,WB30F/WB31F/WB32F
+SAMSUNG,WB350F/WB351F/WB352F
+SAMSUNG," SAMSUNG WB500, WB510 / VLUU WB500 / SAMSUNG HZ10W"
+SAMSUNG,WB5000/HZ25W
+SAMSUNG," SAMSUNG WB550, WB560 / VLUU WB550 / SAMSUNG HZ15W"
+SAMSUNG,SAMSUNG WB600 / VLUU WB600 / SAMSUNG WB610
+SAMSUNG,SAMSUNG WB650 / VLUU WB650 / SAMSUNG WB660
+SAMSUNG,WB690
+SAMSUNG,WB700
+SAMSUNG,SAMSUNG WB750
+SAMSUNG,WB800F
+SAMSUNG,SAMSUNG WB850F/WB855F
+SAMSUNG,SAMSUNG WP10 / VLUU WP10 / SAMSUNG AQ100
+Samsung Electronics,Z240
+Samsung Electronics,Z400
+Samsung Electronics,Z560
+Samsung Electronics,Z720
+Samsung Electronics,ZV50
+Samsung Electronics,ZV60
+Samsung Techwin,"<Samsung i100, Samsung VLUU i100>"
+Samsung Techwin,"<Samsung i7, Samsung VLUU i7>"
+Samsung Techwin,SAMSUNG i70
+Samsung Techwin,"<Samsung i8, Samsung VLUU i8>"
+Samsung,i819 Phone Camera
+Samsung Techwin,"<Samsung i85, Samsung VLUU i85>"
+SAMSUNG ELECTRONICS,SAMSUNG/VP-D590
+"SANYO Electric Co.,Ltd.",1-126-293-00
+SANYO Electric Co.Ltd.,503
+"SANYO Electric Co., Ltd.",603
+"SANYO Electric Co.,Ltd.",A5
+"SANYO Electric Co.,Ltd",AZ1
+"SANYO Electric Co.,Ltd",AZ3
+"SANYO Electric Co.,Ltd.",C1
+"SANYO Electric Co.,Ltd.",C4
+"SANYO Electric Co.,Ltd.",C40
+"SANYO Electric Co.,Ltd.",C5
+"SANYO Electric Co.,Ltd.",C6
+"SANYO Electric Co.,Ltd.",CA6
+"SANYO Electric Co.,Ltd.",CA65
+"SANYO Electric Co.,Ltd.",CG100
+"SANYO Electric Co.,Ltd.",CG6
+"SANYO Electric Co.,Ltd.",CG65
+"SANYO Electric Co.,Ltd.",CG9
+"SANYO Electric Co.,Ltd.",DSC-MZ3
+"SANYO Electric Co.,Ltd.",E1
+"SANYO Electric Co., Ltd.",E1090
+"SANYO Electric Co.,Ltd.",E2
+"SANYO Electric Co.,Ltd.",E6
+"SANYO Electric Co.,Ltd.",E60
+"SANYO Electric Co.,Ltd.",E7
+"SANYO Electric Co., Ltd.",E760
+"SANYO Electric Co., Ltd.",E870
+"SANYO Electric Co.,Ltd.",FH1
+"SANYO Electric Co.,Ltd.",HD1
+"SANYO Electric Co.,Ltd.",HD1000
+"SANYO Electric Co.,Ltd.",HD1A
+"SANYO Electric Co.,Ltd.",HD2
+"SANYO Electric Co.,Ltd.",HD2000
+"SANYO Electric Co.,Ltd.",HD700
+"SANYO Electric Co.,Ltd.",IDC-1000Z
+"SANYO Electric Co.,Ltd",J1
+"SANYO Electric Co.,Ltd",J2
+"SANYO Electric Co.,Ltd.",J4
+"SANYO Electric Co.,Ltd",S1
+SANYO,S103
+"SANYO Electric Co.,Ltd.",S3
+"SANYO Electric Co.,Ltd.",S4
+"SANYO Electric Co.,Ltd.",S5
+"SANYO Electric Co.,Ltd.",S6
+"SANYO Electric Co.,Ltd.",S60
+"SANYO Electric Co., Ltd.",S650
+"SANYO Electric Co.,Ltd.",S70
+SANYO,S750
+"SANYO Electric Co., Ltd.",S760
+"SANYO Electric Co., Ltd.",S770
+"SANYO Electric Co.,Ltd",SR05
+"SANYO Electric Co.,Ltd",SR08
+"SANYO Electric Co.,Ltd.",SR6
+"SANYO Electric Co.,Ltd.",SR66
+"SANYO Electric Co.,Ltd.",SR662
+"SANYO Electric Co.,Ltd",SR813
+"SANYO Electric Co.,Ltd.",SX112
+"SANYO Electric Co.,Ltd.",SX113
+"SANYO Electric Co.,Ltd.",SX114
+"SANYO Electric Co.,Ltd.",SX212
+"SANYO Electric Co.,Ltd.",SX215
+SANYO,V801SA
+"SANYO Electric Co., Ltd.",VPC-E1000
+"SANYO Electric Co.,Ltd.",VPC-MZ3
+"SANYO Electric Co.,Ltd.",VPC-MZ3EX
+"SANYO Electric Co.,Ltd.",VPC-MZ3GX
+" SANYO Electric Co.,Ltd.",VPC-S1080
+"SANYO Electric Co., Ltd.",VPC-S500
+"SANYO Electric Co., Ltd.",VPC-S600
+"SANYO Electric Co., Ltd.",VPC-S700
+"SANYO Electric Co., Ltd.",VPC-T700
+"SANYO Electric Co., Ltd.",VPC-T850EX
+"SANYO Electric Co., Ltd.",VPC-W800
+SANYO,WX310SA
+SeaLife,DC1000
+SeaLife,DC250
+SeaLife,DC300/DC310
+SeaLife,DC500
+SeaLife,DC600
+SeaLife,DC800
+SHARP,705SH
+SHARP,816SH
+SHARP,910SH
+SHARP,912SH
+SHARP,933SH
+SHARP,J-SH010
+SHARP,J-SH51
+SHARP,J-SH52
+SHARP,J-SH53
+SHARP,SX813
+SHARP,SX833
+SHARP,TM150
+SHARP,TM200
+SHARP,V301SH
+SHARP,V401SH
+SHARP,V601SH
+SHARP,V703SH
+SHARP,V801SH
+SHARP,V802SH
+SHARP,V902SH
+SHARP,V903SH
+SHARP,VE-CG30
+SHARP,VE-CG40
+SHARP,VL-AD260
+SHARP,VL-AX1
+SHARP,VL-DD10
+SHARP,VL-MC500
+SHARP,VL-ME100
+SHARP,VL-MG10
+SHARP,VL-MR1
+SHARP,VL-MX1
+SHARP,VL-NZ10
+SHARP,VL-NZ100
+SHARP,VL-NZ105
+SHARP,VL-NZ150
+SHARP,VL-NZ50
+SHARP,VL-NZ8
+SHARP,VL-NZ80
+SHARP,VL-PD7
+SHARP,VL-WD255
+SHARP,VL-WD450
+SHARP,VL-WD650
+SHARP,VL-Z3
+SHARP,VL-Z301
+SHARP,VL-Z5
+SHARP,VL-Z500
+SHARP,VL-Z7
+SHARP,VL-Z700
+SHARP,VL-Z8
+SHARP,VL-Z800
+SHARP,VL-Z950
+SHARP,VL-Z961
+SHARP,VN-EZ1
+SHARP,VN-EZ5
+SHARP,WX-T91
+Sipix Corporation,SC 2100
+Sipix Corporation,SC2300
+Sipix Corporation,SC3300
+Sigma,Sigma BF
+SIGMA,SIGMA DP1
+SIGMA,SIGMA DP1 Merrill
+SIGMA,SIGMA DP1S
+SIGMA,SIGMA DP1X
+SIGMA,SIGMA DP2
+SIGMA,SIGMA DP2 Merrill
+SIGMA,SIGMA DP2S
+SIGMA,SIGMA DP2X
+SIGMA,SIGMA DP3 Merrill
+SIGMA,SIGMA SD1
+SIGMA,SIGMA SD1 Merrill
+SIGMA,SIGMA SD10
+SIGMA,SIGMA SD14
+SIGMA,SIGMA SD15
+SIGMA,SIGMA SD9
+SIGMA,SIGMA dp0 Quattro
+SIGMA,SIGMA dp1 Quattro
+SIGMA,SIGMA dp2 Quattro
+SIGMA,SIGMA dp3 Quattro
+SIGMA,SIGMA fp
+SIGMA,SIGMA fp L
+SIGMA,sd Quattro
+SIGMA,sd Quattro H
+Skanhex,521z3
+Skanhex Technology Inc.,524Z3 Digital Camera
+SKANHEX,636Z3
+SkanHex Tech,SK-210M
+Skanhex,SX-130F
+"SKANHEX TECHWIN CO,LTD",SX-210Z3
+"SKANHEX TECHWIN CO,LTD",SX-330Z3
+"SKANHEX TECHWIN CO,LTD",SX-410Z3
+"SKANHEX  OPTICAL CO,LTD",SX3300
+"  SKANHEX OPTICAL CO,LTD",SX410Z3
+SONY,SONY
+Sony,C5303
+Sony,C6502
+Sony,C6603
+Sony,C6833
+Sony,C6902
+Sony,C6903
+SONY,CD MAVICA
+SONY,CLIE
+SONY,CYBERSHOT
+SONY,CYBERSHOT U
+Sony,D5503
+Sony,D5833
+Sony,D6503
+Sony,D6603
+Sony,D6653
+SONY,DCR-DVD100
+SONY,DCR-DVD100E
+SONY,DCR-DVD101
+SONY,DCR-DVD101E
+SONY,DCR-DVD105
+SONY,DCR-DVD105E
+SONY,DCR-DVD106E
+SONY,DCR-DVD108
+SONY,DCR-DVD108E
+SONY,DCR-DVD109E
+SONY,DCR-DVD110E
+SONY,DCR-DVD115E
+SONY,DCR-DVD200
+SONY,DCR-DVD200E
+SONY,DCR-DVD201
+SONY,DCR-DVD201E
+SONY,DCR-DVD202E
+SONY,DCR-DVD203
+SONY,DCR-DVD203E
+SONY,DCR-DVD205
+SONY,DCR-DVD205E
+SONY,DCR-DVD300
+SONY,DCR-DVD301
+SONY,DCR-DVD304E
+SONY,DCR-DVD305
+SONY,DCR-DVD305E
+SONY,DCR-DVD306E
+SONY,DCR-DVD308
+SONY,DCR-DVD308E
+SONY,DCR-DVD310E
+SONY,DCR-DVD403
+SONY,DCR-DVD403E
+SONY,DCR-DVD404E
+SONY,DCR-DVD405
+SONY,DCR-DVD405E
+SONY,DCR-DVD406E
+SONY,DCR-DVD408
+SONY,DCR-DVD408E
+SONY,DCR-DVD450E
+SONY,DCR-DVD505
+SONY,DCR-DVD505E
+SONY,DCR-DVD506E
+SONY,DCR-DVD508E
+SONY,DCR-DVD602E
+SONY,DCR-DVD605E
+SONY,DCR-DVD608E
+SONY,DCR-DVD610E
+SONY,DCR-DVD650E
+SONY,DCR-DVD653E
+SONY,DCR-DVD7
+SONY,DCR-DVD703
+SONY,DCR-DVD703E
+SONY,DCR-DVD705E
+SONY,DCR-DVD708
+SONY,DCR-DVD708E
+SONY,DCR-DVD710
+SONY,DCR-DVD710E
+SONY,DCR-DVD755
+SONY,DCR-DVD755E
+SONY,DCR-DVD7E
+SONY,DCR-DVD803
+SONY,DCR-DVD803E
+SONY,DCR-DVD805
+SONY,DCR-DVD805E
+SONY,DCR-DVD808
+SONY,DCR-DVD808E
+SONY,DCR-DVD810
+SONY,DCR-DVD810E
+SONY,DCR-DVD905
+SONY,DCR-DVD905E
+SONY,DCR-DVD908E
+SONY,DCR-DVD910E
+SONY,DCR-DVD91E
+SONY,DCR-DVD92
+SONY,DCR-DVD92E
+SONY,DCR-HC1000
+SONY,DCR-HC1000E
+SONY,DCR-HC30
+SONY,DCR-HC30E
+SONY,DCR-HC32
+SONY,DCR-HC32E
+SONY,DCR-HC33E
+SONY,DCR-HC36
+SONY,DCR-HC36E
+SONY,DCR-HC39E
+SONY,DCR-HC40
+SONY,DCR-HC40E
+SONY,DCR-HC42
+SONY,DCR-HC42E
+SONY,DCR-HC43E
+SONY,DCR-HC44E
+SONY,DCR-HC46
+SONY,DCR-HC46E
+SONY,DCR-HC47E
+SONY,DCR-HC48E
+SONY,DCR-HC62E
+SONY,DCR-HC65
+SONY,DCR-HC85
+SONY,DCR-HC85E
+SONY,DCR-HC88
+SONY,DCR-HC90
+SONY,DCR-HC90E
+SONY,DCR-HC94E
+SONY,DCR-HC96
+SONY,DCR-HC96E
+SONY,RENSLUkUMUU=
+SONY,DCR-IP1
+SONY,DCR-IP210
+SONY,DCR-IP210E
+SONY,DCR-IP220
+SONY,DCR-IP220E
+SONY,DCR-IP45
+SONY,DCR-IP45E
+SONY,DCR-IP55
+SONY,DCR-IP55E
+SONY,DCR-IP7
+SONY,DCR-IP7E
+SONY,DCR-PC100
+SONY,DCR-PC1000
+SONY,DCR-PC1000E
+SONY,DCR-PC101
+SONY,DCR-PC101E
+SONY,DCR-PC105
+SONY,DCR-PC105E
+SONY,DCR-PC108E
+SONY,DCR-PC109
+SONY,DCR-PC109E
+SONY,DCR-PC110
+SONY,DCR-PC110E
+SONY,DCR-PC115
+SONY,DCR-PC115E
+SONY,DCR-PC120
+SONY,DCR-PC120E
+SONY,DCR-PC3
+SONY,DCR-PC300
+SONY,DCR-PC330
+SONY,DCR-PC330E
+SONY,DCR-PC350
+SONY,DCR-PC350E
+SONY,DCR-PC5
+SONY,DCR-PC53E
+SONY,DCR-PC55
+SONY,DCR-PC55E
+SONY,DCR-PC5E
+SONY,DCR-PC9
+SONY,DCR-PC9E
+SONY,DCR-SR100
+SONY,DCR-SR100E
+SONY,DCR-SR190E
+SONY,DCR-SR200
+SONY,DCR-SR200E
+SONY,DCR-SR210E
+SONY,DCR-SR220E
+SONY,DCR-SR290E
+SONY,DCR-SR300
+SONY,DCR-SR300E
+SONY,DCR-SR30E
+SONY,DCR-SR32E
+SONY,DCR-SR33E
+SONY,DCR-SR35E
+SONY,DCR-SR36E
+SONY,DCR-SR37E
+SONY,DCR-SR38E
+SONY,DCR-SR40
+SONY,DCR-SR40E
+SONY,DCR-SR42
+SONY,DCR-SR42E
+SONY,DCR-SR45E
+SONY,DCR-SR46
+SONY,DCR-SR46E
+SONY,DCR-SR47E
+SONY,DCR-SR48E
+SONY,DCR-SR50E
+SONY,DCR-SR52E
+SONY,DCR-SR55E
+SONY,DCR-SR60E
+SONY,DCR-SR62
+SONY,DCR-SR62E
+SONY,DCR-SR65E
+SONY,DCR-SR67E
+SONY,DCR-SR68E
+SONY,DCR-SR70E
+SONY,DCR-SR72E
+SONY,DCR-SR75E
+SONY,DCR-SR80E
+SONY,DCR-SR82E
+SONY,DCR-SR85E
+SONY,DCR-SR87
+SONY,DCR-SR87E
+SONY,DCR-SR88E
+SONY,DCR-SR90E
+SONY,DCR-SX15E
+SONY,DCR-SX20E
+SONY,DCR-SX30E
+SONY,DCR-SX40E
+SONY,DCR-SX41E
+SONY,DCR-SX43E
+SONY,DCR-SX44E
+SONY,DCR-SX45E
+SONY,DCR-SX53E
+SONY,DCR-SX60E
+SONY,DCR-SX63E
+SONY,DCR-SX65E
+SONY,DCR-SX83E
+SONY,DCR-SX85E
+SONY,DCR-TRV10
+SONY,DCR-TRV11
+SONY,DCR-TRV11E
+SONY,DCR-TRV17
+SONY,DCR-TRV17E
+SONY,DCR-TRV18
+SONY,DCR-TRV18E
+SONY,DCR-TRV20
+SONY,DCR-TRV20E
+SONY,DCR-TRV22
+SONY,DCR-TRV22E
+SONY,DCR-TRV24E
+SONY,DCR-TRV25
+SONY,DCR-TRV25E
+SONY,DCR-TRV27
+SONY,DCR-TRV27E
+SONY,DCR-TRV30
+SONY,DCR-TRV30E
+SONY,DCR-TRV320
+SONY,DCR-TRV320E
+SONY,DCR-TRV325E
+SONY,DCR-TRV33
+SONY,DCR-TRV330
+SONY,DCR-TRV330E
+SONY,DCR-TRV33E
+SONY,DCR-TRV340
+SONY,DCR-TRV340E
+SONY,DCR-TRV350
+SONY,DCR-TRV351
+SONY,DCR-TRV355E
+SONY,DCR-TRV356E
+SONY,DCR-TRV361
+SONY,DCR-TRV38
+SONY,DCR-TRV38E
+SONY,DCR-TRV39
+SONY,DCR-TRV40
+SONY,DCR-TRV40E
+SONY,DCR-TRV420E
+SONY,DCR-TRV430E
+SONY,DCR-TRV460
+SONY,DCR-TRV460E
+SONY,DCR-TRV480E
+SONY,DCR-TRV50
+SONY,DCR-TRV50E
+SONY,DCR-TRV510
+SONY,DCR-TRV520
+SONY,DCR-TRV520E
+SONY,DCR-TRV525
+SONY,DCR-TRV530
+SONY,DCR-TRV530E
+SONY,DCR-TRV60
+SONY,DCR-TRV60E
+SONY,DCR-TRV620
+SONY,DCR-TRV620E
+SONY,DCR-TRV70
+SONY,DCR-TRV720
+SONY,DCR-TRV720E
+SONY,DCR-TRV725E
+SONY,DCR-TRV730
+SONY,DCR-TRV730E
+SONY,DCR-TRV740
+SONY,DCR-TRV740E
+SONY,DCR-TRV75
+SONY,DCR-TRV75E
+SONY,DCR-TRV80
+SONY,DCR-TRV80E
+SONY,DCR-TRV820
+SONY,DCR-TRV820E
+SONY,DCR-TRV828E
+SONY,DCR-TRV830
+SONY,DCR-TRV830E
+SONY,DCR-TRV840
+SONY,DCR-TRV940E
+SONY,DCR-TRV950
+SONY,DCR-TRV950E
+SONY,DCR-VX2000
+SONY,DCR-VX2100
+SONY,DCR-VX2100E
+SONY,DCR-VX2200E
+SONY,DPP-FP60(AF1)
+SONY,DPP-SV55
+SONY,DSC-D700
+SONY,DSC-D770
+SONY,DSC-F828
+SONY,DSC-F88
+SONY,DSC-G1
+SONY,DSC-G3
+SONY,DSC-H00
+SONY,DSC-H1
+SONY,DSC-H10
+SONY,DSC-H2
+SONY,DSC-H20
+SONY,DSC-H200
+SONY,DSC-H3
+SONY,DSC-H300
+SONY,DSC-H400
+SONY,DSC-H5
+SONY,DSC-H50
+SONY,DSC-H55
+SONY,DSC-H7
+SONY,DSC-H9
+SONY,DSC-H90
+SONY,DSC-HX1
+SONY,DSC-HX100V
+SONY,DSC-HX10V
+SONY,DSC-HX200V
+SONY,DSC-HX20V
+SONY,DSC-HX300
+SONY,DSC-HX30V
+SONY,DSC-HX350
+SONY,DSC-HX400V
+SONY,DSC-HX5
+SONY,DSC-HX50
+SONY,DSC-HX50V
+SONY,DSC-HX5C
+SONY,DSC-HX5V
+SONY,DSC-HX60V
+SONY,DSC-HX7V
+SONY,DSC-HX80
+SONY,DSC-HX90
+SONY,DSC-HX90V
+SONY,DSC-HX99
+SONY,DSC-HX9V
+SONY,DSC-J10
+SONY,DSC-L1
+SONY,DSC-M1
+SONY,DSC-M2
+SONY,DSC-N1
+SONY,DSC-N2
+SONY,DSC-P10
+SONY,DSC-P100
+SONY,DSC-P12
+SONY,DSC-P120
+SONY,DSC-P150
+SONY,DSC-P200
+SONY,DSC-P32
+SONY,DSC-P41
+SONY,DSC-P43
+SONY,DSC-P52
+SONY,DSC-P72
+SONY,DSC-P73
+SONY,DSC-P8
+SONY,DSC-P92
+SONY,DSC-P93
+SONY,DSC-P93A
+SONY,DSC-QX10
+SONY,DSC-QX100
+SONY,DSC-QX30
+SONY,DSC-R1
+SONY,DSC-RX0
+SONY,DSC-RX0M2
+SONY,DSC-RX1
+SONY,DSC-RX10
+SONY,DSC-RX100
+SONY,DSC-RX100M2
+SONY,DSC-RX100M3
+SONY,DSC-RX100M4
+SONY,DSC-RX100M5
+SONY,DSC-RX100M5A
+SONY,DSC-RX100M6
+SONY,DSC-RX100M7
+SONY,DSC-RX100M7A
+SONY,DSC-RX10M2
+SONY,DSC-RX10M3
+SONY,DSC-RX10M4
+SONY,DSC-RX1R
+SONY,DSC-RX1RM2
+SONY,DSC-RX1RM3
+SONY,DSC-S1900
+SONY,DSC-S2000
+SONY,DSC-S2100
+SONY,DSC-S3000
+SONY,DSC-S40
+SONY,DSC-S45
+SONY,DSC-S500
+SONY,DSC-S5000
+SONY,DSC-S60
+SONY,DSC-S600
+SONY,DSC-S650
+SONY,DSC-S700
+SONY,DSC-S730
+SONY,DSC-S750
+SONY,DSC-S780
+SONY,DSC-S80
+SONY,DSC-S800
+SONY,DSC-S90
+SONY,DSC-S930
+SONY,DSC-S950
+SONY,DSC-S980
+SONY,DSC-ST80
+SONY,DSC-T00
+SONY,DSC-T1
+SONY,DSC-T10
+SONY,DSC-T100
+SONY,DSC-T11
+SONY,DSC-T110
+SONY,DSC-T2
+SONY,DSC-T20
+SONY,DSC-T200
+SONY,DSC-T25
+SONY,DSC-T3
+SONY,DSC-T30
+SONY,DSC-T300
+SONY,DSC-T33
+SONY,DSC-T5
+SONY,DSC-T50
+SONY,DSC-T500
+SONY,DSC-T7
+SONY,DSC-T70
+SONY,DSC-T700
+SONY,DSC-T75
+SONY,DSC-T77
+SONY,DSC-T9
+SONY,DSC-T90
+SONY,DSC-T900
+SONY,DSC-T99
+SONY,DSC-TF1
+SONY,DSC-TX1
+SONY,DSC-TX10
+SONY,DSC-TX100
+SONY,DSC-TX100V
+SONY,DSC-TX20
+SONY,DSC-TX200V
+SONY,DSC-TX30
+SONY,DSC-TX300V
+SONY,DSC-TX5
+SONY,DSC-TX55
+SONY,DSC-TX66
+SONY,DSC-TX7
+SONY,DSC-TX9
+SONY,DSC-U30
+SONY,DSC-U40
+SONY,DSC-U50
+SONY,DSC-U60
+SONY,DSC-V1
+SONY,DSC-V3
+SONY,DSC-W1
+SONY,DSC-W100
+SONY,DSC-W110
+SONY,DSC-W115
+SONY,DSC-W12
+SONY,DSC-W120
+SONY,DSC-W125
+SONY,DSC-W130
+SONY,DSC-W15
+SONY,DSC-W150
+SONY,DSC-W17
+SONY,DSC-W170
+SONY,DSC-W180
+SONY,DSC-W190
+SONY,DSC-W200
+SONY,DSC-W210
+SONY,DSC-W215
+SONY,DSC-W220
+SONY,DSC-W230
+SONY,DSC-W270
+SONY,DSC-W275
+SONY,DSC-W290
+SONY,DSC-W30
+SONY,DSC-W300
+SONY,DSC-W310
+SONY,DSC-W320
+SONY,DSC-W330
+SONY,DSC-W35
+SONY,DSC-W350
+SONY,DSC-W360
+SONY,DSC-W370
+SONY,DSC-W380
+SONY,DSC-W390
+SONY,DSC-W40
+SONY,DSC-W5
+SONY,DSC-W50
+SONY,DSC-W510
+SONY,DSC-W530
+SONY,DSC-W55
+SONY,DSC-W560
+SONY,DSC-W570
+SONY,DSC-W610
+SONY,DSC-W620
+SONY,DSC-W650
+SONY,DSC-W690
+SONY,DSC-W7
+SONY,DSC-W70
+SONY,DSC-W710
+SONY,DSC-W730
+SONY,DSC-W80
+SONY,DSC-W800
+SONY,DSC-W810
+SONY,DSC-W830
+SONY,DSC-W85
+SONY,DSC-W90
+SONY,DSC-WX1
+SONY,DSC-WX10
+SONY,DSC-WX100
+SONY,DSC-WX150
+SONY,DSC-WX200
+SONY,DSC-WX220
+SONY,DSC-WX30
+SONY,DSC-WX300
+SONY,DSC-WX350
+SONY,DSC-WX5
+SONY,DSC-WX50
+SONY,DSC-WX500
+SONY,DSC-WX60
+SONY,DSC-WX7
+SONY,DSC-WX70
+SONY,DSC-WX80
+SONY,DSC-WX9
+SONY,DSLR-A100
+SONY,DSLR-A200
+SONY,DSLR-A230
+SONY,DSLR-A290
+SONY,DSLR-A300
+SONY,DSLR-A330
+SONY,DSLR-A350
+SONY,DSLR-A380
+SONY,DSLR-A390
+SONY,DSLR-A450
+SONY,DSLR-A500
+SONY,DSLR-A550
+SONY,DSLR-A560
+SONY,DSLR-A580
+SONY,DSLR-A700
+SONY,DSLR-A850
+SONY,DSLR-A900
+SONY,DSR-250P
+SONY,DSR-PD150
+SONY,DSR-PD150P
+SONY,DSR-PD170P
+SONY,DSR-PD175P
+SONY,DSR-PD190P
+SONY,DSR-PDX10
+SONY,DSR-PDX10P
+SONY,DVgate Still
+Sony,E2306
+Sony,E5823
+Sony,E6653
+Sony,E6853
+Sony Ericsson,C510
+Sony Ericsson,C702
+Sony Ericsson,C901
+Sony Ericsson,C902
+Sony Ericsson,C902c
+Sony Ericsson,C903
+Sony Ericsson,C905
+Sony Ericsson,D750i
+Sony Ericsson,E10i
+Sony Ericsson,E15i
+Sony Ericsson,F100i
+Sony Ericsson,F305
+Sony Ericsson,G502
+SONY ERICSSON,SONY ERICSSON G700
+Sony Ericsson,G705
+SONY ERICSSON,SONY ERICSSON G900
+Sony Ericsson,J105i
+Sony Ericsson,J10i2
+Sony Ericsson,J20i
+Sony Ericsson,K300i
+Sony Ericsson,K310a
+Sony Ericsson,K310i
+Sony Ericsson,K320i
+Sony Ericsson,K510a
+Sony Ericsson,K510c
+Sony Ericsson,K510i
+Sony Ericsson,K530c
+Sony Ericsson,K530i
+Sony Ericsson,K550c
+Sony Ericsson,K550i
+Sony Ericsson,K550im
+Sony Ericsson,K600
+Sony Ericsson,K600i
+Sony Ericsson,K608i
+Sony Ericsson,K610i
+Sony Ericsson,K610im
+Sony Ericsson,K618i
+Sony Ericsson,K630i
+Sony Ericsson,K660i
+Sony Ericsson,K700
+Sony Ericsson,K750c
+Sony Ericsson,K750i
+Sony Ericsson,K770i
+Sony Ericsson,K790a
+Sony Ericsson,K790c
+Sony Ericsson,K790i
+Sony Ericsson,K800c
+Sony Ericsson,K800i
+Sony Ericsson,K810i
+Sony Ericsson,K850i
+Sony Ericsson,LT15i
+Sony Ericsson,LT18i
+Sony Ericsson,LT26i
+SONY ERICSSON,SONY ERICSSON M600i
+SONY ERICSSON,SONY ERICSSON P1i
+SONY ERICSSON,SONY ERICSSON P900
+SONY ERICSSON,SONY ERICSSON P990i
+Sony Ericsson,S302
+Sony Ericsson,S312
+Sony Ericsson,S500i
+Sony Ericsson,S700c
+Sony Ericsson,S700i
+Sony Ericsson,S710a
+Sony Ericsson,SK17i
+Sony Ericsson,T650i
+Sony Ericsson,T700
+Sony Ericsson,T707
+Sony Ericsson,T715
+Sony Ericsson,U100i
+Sony Ericsson,U10i
+Sony Ericsson,U1i
+Sony Ericsson,U20i
+Sony Ericsson,U5i
+Sony Ericsson,U8i
+Sony Ericsson,V600i
+Sony Ericsson,V630i
+Sony Ericsson,V640i
+Sony Ericsson,V800
+Sony Ericsson,Vodafone-802SE
+Sony Ericsson,W200a
+Sony Ericsson,W200i
+SONY ERICSSON,SONY ERICSSON W205
+Sony Ericsson,W20i
+Sony Ericsson,W300i
+Sony Ericsson,W302
+Sony Ericsson,W350a
+Sony Ericsson,W350i
+Sony Ericsson,W380a
+Sony Ericsson,W380i
+Sony Ericsson,W395
+Sony Ericsson,W508
+Sony Ericsson,W550c
+Sony Ericsson,W550i
+Sony Ericsson,W580c
+Sony Ericsson,W580i
+Sony Ericsson,W595
+Sony Ericsson,W600i
+Sony Ericsson,W610c
+Sony Ericsson,W610i
+Sony Ericsson,W660i
+Sony Ericsson,W700i
+Sony Ericsson,W705
+Sony Ericsson,W710i
+Sony Ericsson,W715
+Sony Ericsson,W760i
+Sony Ericsson,W800c
+Sony Ericsson,W800i
+Sony Ericsson,W810c
+Sony Ericsson,W810i
+Sony Ericsson,W830i
+Sony Ericsson,W850i
+Sony Ericsson,W880i
+Sony Ericsson,W888c
+Sony Ericsson,W890i
+Sony Ericsson,W900i
+Sony Ericsson,W902
+Sony Ericsson,W908c
+Sony Ericsson,W910i
+SONY ERICSSON,SONY ERICSSON W950i
+SONY ERICSSON,SONY ERICSSON W960i
+Sony Ericsson,W980
+Sony Ericsson,W995
+SonyEricsson,XPERIA X1
+Sony Ericsson,XPERIA X2
+Sony Ericsson,XPeria X10
+Sony Ericsson,Z1010
+Sony Ericsson,Z310i
+Sony Ericsson,Z520a
+Sony Ericsson,Z520i
+Sony Ericsson,Z525
+Sony Ericsson,Z530i
+Sony Ericsson,Z550i
+Sony Ericsson,Z555i
+Sony Ericsson,Z558c
+Sony Ericsson,Z610i
+Sony Ericsson,Z710c
+Sony Ericsson,Z710i
+Sony Ericsson,Z750i
+Sony Ericsson,Z770i
+Sony Ericsson,Z800
+Sony Ericsson,Z800i
+SONY ERICSSON,SONY ERICSSON p910a
+SONY ERICSSON,SONY ERICSSON p910i
+Sony Ericsson,w790i
+Sony,F5321
+Sony,F8331
+SONY,FDMAVICA
+SONY,FDR-X1000V
+SONY,FDR-X3000
+Sony,G8441
+SONY,GV-D1000
+Sony,H8416
+SONY,HANDYCAM
+SONY,HDR-AS10
+SONY,HDR-AS15
+SONY,HDR-AS20
+SONY,HDR-AS200V
+SONY,HDR-AS300
+SONY,HDR-AS30V
+SONY,HDR-AX2000E
+SONY,HDR-CX100
+SONY,HDR-CX100E
+SONY,HDR-CX105E
+SONY,HDR-CX110E
+SONY,HDR-CX12
+SONY,HDR-CX12E
+SONY,HDR-CX130E
+SONY,HDR-CX150E
+SONY,HDR-CX160E
+SONY,HDR-CX350E
+SONY,HDR-CX360
+SONY,HDR-CX360E
+SONY,HDR-CX500E
+SONY,HDR-CX520E
+SONY,HDR-CX550E
+SONY,HDR-CX560E
+SONY,HDR-CX6EK
+SONY,HDR-CX700E
+SONY,HDR-CX7EK
+SONY,HDR-FX7E
+SONY,HDR-HC1
+SONY,HDR-HC1E
+SONY,HDR-HC3
+SONY,HDR-HC3E
+SONY,HDR-HC5
+SONY,HDR-HC5E
+SONY,HDR-HC7
+SONY,HDR-HC7E
+SONY,HDR-HC9
+SONY,HDR-HC9E
+SONY,HDR-PJ10E
+SONY,HDR-PJ30E
+SONY,HDR-SR1
+SONY,HDR-SR10E
+SONY,HDR-SR11
+SONY,HDR-SR11E
+SONY,HDR-SR12
+SONY,HDR-SR12E
+SONY,HDR-SR1E
+SONY,HDR-SR5
+SONY,HDR-SR5E
+SONY,HDR-SR7
+SONY,HDR-SR7E
+SONY,HDR-SR8E
+SONY,HDR-TG1
+SONY,HDR-TG1E
+SONY,HDR-TG3E
+SONY,HDR-TG5E
+SONY,HDR-UX10E
+SONY,HDR-UX1E
+SONY,HDR-UX20
+SONY,HDR-UX20E
+SONY,HDR-UX3E
+SONY,HDR-UX5E
+SONY,HDR-UX7E
+SONY,HDR-XR100E
+SONY,HDR-XR105E
+SONY,HDR-XR106E
+SONY,HDR-XR150E
+SONY,HDR-XR200E
+SONY,HDR-XR350E
+SONY,HDR-XR500E
+SONY,HDR-XR500V
+SONY,HDR-XR500VE
+SONY,HDR-XR520
+SONY,HDR-XR520E
+SONY,HDR-XR520V
+SONY,HDR-XR520VE
+SONY,HDR-XR550
+SONY,HVR-A1E
+SONY,HVR-A1U
+SONY,HVR-HD1000E
+SONY,HVR-V1E
+SONY,HVR-Z5E
+SONY,HVR-Z7E
+SONY,HXR-MC1500P
+SONY,ILCA-68
+SONY,ILCA-77M2
+SONY,ILCA-99M2
+SONY,ILCE-1
+SONY,ILCE-1M2
+SONY,ILCE-3000
+SONY,ILCE-3500
+SONY,ILCE-5000
+SONY,ILCE-5100
+SONY,ILCE-6000
+SONY,ILCE-6100
+SONY,ILCE-6300
+SONY,ILCE-6400
+SONY,ILCE-6400A
+SONY,ILCE-6500
+SONY,ILCE-6600
+SONY,ILCE-6700
+SONY,ILCE-7
+SONY,ILCE-7C
+SONY,ILCE-7CM2
+SONY,ILCE-7CR
+SONY,ILCE-7M2
+SONY,ILCE-7M3
+SONY,ILCE-7M4
+SONY,ILCE-7R
+SONY,ILCE-7RM2
+SONY,ILCE-7RM3
+SONY,ILCE-7RM4
+SONY,ILCE-7RM5
+SONY,ILCE-7S
+SONY,ILCE-7SM2
+SONY,ILCE-7SM3
+SONY,ILCE-9
+SONY,ILCE-9M2
+SONY,ILCE-9M3
+SONY,ILCE-QX1
+SONY,ILME-FX2
+SONY,ILME-FX3
+SONY,ILME-FX30
+Sony,J8110
+Sony,J8210
+SONY,MAVICA
+SONY,MHS-CM1
+SONY,MHS-CM5
+SONY,MHS-PM1
+SONY,MHS-PM5
+SONY,MHS-TS20
+SONY,MVC-CD350
+SONY,MVC-CD500
+SONY,NEX-3
+SONY,NEX-3N
+SONY,NEX-5
+SONY,NEX-5N
+SONY,NEX-5T
+SONY,NEX-6
+SONY,NEX-7
+SONY,NEX-C3
+SONY,NEX-F3
+SONY,NEX-VG10E
+SONY,NEX-VG20E
+SONY,NEX-VG30E
+SONY,NEX-VG900
+SONY,NSC-GC1
+Sony Computer Entertainment Inc.,PSP-300
+Sony,PictureGear
+SONY,SLT-A33
+SONY,SLT-A35
+SONY,SLT-A37
+SONY,SLT-A55
+SONY,SLT-A55V
+SONY,SLT-A57
+SONY,SLT-A58
+SONY,SLT-A65
+SONY,SLT-A65V
+SONY,SLT-A77
+SONY,SLT-A77V
+SONY,SLT-A99
+SONY,SLT-A99V
+SONY Corporation,UPX
+Sony,XQ-AS52
+Sony,XQ-AT51
+Sony,XQ-BC52
+Sony,XQ-BE52
+Sony,XQ-BQ52
+Sony,XQ-CT54
+Sony,XQ-EC54
+SONY,Xperia M2
+SONY,ZV-1
+SONY,ZV-1A
+SONY,ZV-1F
+SONY,ZV-1M2
+SONY,ZV-E1
+SONY,ZV-E10
+SONY,ZV-E10M2
+Sprint,KATANA DLX
+Sunplus,DVC202
+Sunplus,DVC302
+Sunplus,Spca533
+Supra,DC 5900
+Supra,DC 7900
+Supra,DC-6900
+Supra,DC-8600
+Supra,DC-XZ6
+Supra,DC6800
+Supra,DV 5060
+SUPRA,MAGINON X50
+SUPRA,MAGINON X60
+SUPRA,SLIMLINE X6
+Supra,Super Slim XS7
+Supra,Super Slim XS70
+SUPRA,TCM X50
+Supra,Traveler DV 5040
+T-Mobile Shadow,T-Mobile Shadow
+T-Mobile(R),Sidekick 2008
+T-Mobile(R),Sidekick(R) 3
+T-Mobile(R),Sidekick LX
+T-Mobile(R),Sidekick Slide
+TCG,PDC2150
+TESCO,LDC-825Z3
+TRAVELER,SLIMLINE X5
+TRUST,1210K POWERC@M OPTICAL ZOOM
+TRUST,760 POWERC@M
+TRUST,913 POWER
+TRUST,960 POWERC@M
+TRUST,962Z POWER
+TRUST,DC3500 MINI
+Telechips,SAMSUNG SGH-E740
+Telechips,SAMSUNG SGH-J210
+TOSHIBA,811T
+TOSHIBA,910T
+TOSHIBA,921T
+TOSHIBA,Camileo Pro HD
+TOSHIBA,Camileo Pro HDDV
+Toshiba,Toshiba G810 3.0 MP CMOS SENSOR
+TOSHIBA,G910/G920
+TOSHIBA,J-T010
+Toshiba Corporation,PDR M11
+Toshiba Corporation,PDR M21
+TOSHIBA,PDR-2
+TOSHIBA,PDR-3300
+TOSHIBA,PDR-3310
+Toshiba,PDR-3320
+TOSHIBA,PDR-3330
+TOSHIBA,PDR-4300
+TOSHIBA,PDR-5
+TOSHIBA,PDR-5300
+TOSHIBA,PDR-M1
+Toshiba,PDR-M25
+TOSHIBA,PDR-M3
+TOSHIBA,PDR-M4
+TOSHIBA,PDR-M500
+Toshiba,PDR-M60
+Toshiba,PDR-M61
+Toshiba,PDR-M65
+TOSHIBA,PDR-M700
+TOSHIBA,PDR-M71
+TOSHIBA,PDR-T10
+TOSHIBA,PDR-T15
+TOSHIBA,PDR-T20
+TOSHIBA,PDR-T30
+TOSHIBA,PDR2300
+TOSHIBA,PDRM40
+TOSHIBA,PDRM5
+TOSHIBA,PDRM70
+TOSHIBA,PDRM81
+TOSHIBA,TG01
+TOSHIBA,TS705
+TOSHIBA,camesse petit
+Traveler,DC-4300
+Traveler,DC-8300
+Traveler,HS 9
+"TRAVELER OPTICAL CO,LTD",SX330Z
+"TRAVELER OPTICAL CO,LTD",TRAVELER 410Z
+  Traveler,Super Slim X8
+Trust,550 POWER
+Trust,738AV LCD PV
+Trust,950 PowerC@m Zoom
+Trust Computer Products,1220S PowerC@m Optical Zoom
+Trust,DC-4200 CAM
+Trust,DSC
+Trust,Gemini11
+UMAX,AstraPix 590
+UMAX,AstraSlim F4
+Uniden Corporation,UDC-5M
+VISTAQUEST,VQ1015
+SAMSUNG,VLUU ES20/ SAMSUNG ES20
+Samsung,"VLUU L100, M100  / Samsung L100, M100"
+Samsung Techwin,VLUU L110  / Samsung L110
+Samsung Techwin,VLUU L200  / Samsung L200
+Samsung Techwin,VLUU L210  / Samsung L210
+Samsung Techwin,VLUU L310W  / Samsung L310W
+SAMSUNG,VLUU L310W L313 M310W / Samsung L310W L313 M310W
+Samsung Techwin,<VLUU L730  / Samsung L730>
+Samsung Techwin,<VLUU L830  / Samsung L830>
+"SAMSUNG TECHWIN CO., LTD.",VLUU L83T/ Samsung L83T
+SAMSUNG,VLUU PL65/ SAMSUNG PL65
+SAMSUNG,"VLUU SH100, SAMSUNG SH100"
+SAMSUNG,VLUU ST50/ SAMSUNG ST50
+SAMSUNG,"VLUU ST6500, SAMSUNG ST6500"
+SAMSUNG,"VLUU ST95, SAMSUNG ST95"
+SAMSUNG,"VLUU WB210, SAMSUNG WB210"
+"Samsung Techwin co., Ltd.",VLUU i80/ Samsung i80/ VLUU i800
+VTech,Kidizoom camera
+Victor,GC-X1
+Victor,GC-X3
+ViewQuest,VQ-2110
+ViviCam,
+ViviCam,8010
+ViviCam,T328
+ViviCam,V5024
+ViviCam,V8025
+VIVITAR,DVR-200
+VIVITAR,DVR-210
+VIVITAR,DVR-310
+VIVITAR,DVR-530
+VIVITAR,DVR310
+Vivitar,V 3755
+Vivitar Corporation,V3345
+Vivitar Corporation,V3826 Digital Camera
+Vivitar Corporation,V3935 Digital Camera
+Vivitar corporation,Vivi cam3730
+Vivitar Corporation.,ViviCam
+Vivitar,Vivicam 2005
+Vivitar,ViviCam 3105s
+Vivitar,ViviCam 3350B
+Vivitar Corporation,ViviCam 3705
+Vivitar,Vivicam 3705B
+Vivitar,Vivicam 3715
+Vivitar,ViviCam3746
+Vivitar Corporation,Vivicam 3750
+Vivitar Corporation,Vivicam 3760
+Vivitar,ViviCam 3765
+Vivitar Corporation,Vivicam 3780s
+Vivitar Corporation.,Vivicam 3785
+Vivitar,ViviCam 3786s
+Vivitar,Vivicam3815
+Vivitar,Vivicam3830s
+Vivitar,ViviCam 3835
+Vivitar,Vivicam3915
+Vivitar,Vivicam3930
+VIVITAR,ViviCam 3945S
+Vivitar,Vivicam4000
+Vivitar,Vivicam 4100
+Vivitar Corporation,Vivicam 4345
+Vivitar,ViviCam5010
+Vivitar,Vivicam 5105s
+Vivitar,Vivicam5150s
+Vivitar corporation,Vivicam 5199
+VIVITAR,VIVICAM 5340S
+Vivitar,ViviCam5355
+Vivitar,ViviCam 5388
+Vivitar,Vivicam6150s
+Vivitar,ViviCam 6300
+Vivitar,ViviCam 6320
+Vivitar,ViviCam 6324
+Vivitar,ViviCam 6330s
+Vivitar,ViviCam7100s
+Vivitar,ViviCam 7310
+Vivitar,ViviCam 7320
+Vivitar,ViviCam 7330
+VIVITAR,ViviCam 7340
+Vivitar Corporation,Vivicam 8300s
+Vivitar,Vivicam 8320
+VIVITAR,ViviCam8340
+   Vivitar,ViviCam 8380
+Vivitar,Vivicam 8400
+Vivitar,ViviCam X30
+Vivitar,ViviCamX325
+Vivitar,ViviCam X345
+Vivitar,ViviCam X625
+vivo,V2006
+vivo,V2114
+vivo,V2145
+vivo,vivo X100 Pro
+VODAFONE 710,Vodafone 710
+Vodafone Group,Vodafone 715
+Vodafone,V602SH
+VODAFONE V720,Vodafone V720
+Vodafone,V803T
+VODAFONE V810,Vodafone V810
+Vodafone,V902T
+Vodafone,V903T
+WIA,1200 UB Plus
+WIA,2400CU Plus
+WIA,MUSTEK 1248UB
+WWL Corporation,DZIGN 1.0
+WWL,ION300
+WWL,MISS
+"WWL .,LTD",MovixII
+WWL,PDC1070
+WWL,PDC2050
+WWL,PDC2070
+WWL,PDC3030
+WWL,PDC3035
+WWL,PDC3070
+WWL,PDC3077
+WWL,Polaroid PDC 3150
+WWL,Polaroid PDC2350
+WWL,Polaroid PDC3050
+WWL,Polaroid PDC3350
+WWL,Tinio
+"WWL .,LTD",Vista
+Xiaomi,21081111RG
+XIAOMI,HM1S
+Xiaomi,M2010J19SY
+Xiaomi,M2101K6G
+Xiaomi,M2102K1G
+Xiaomi,MI 4S
+Xiaomi,MI 5
+Xiaomi,MI 8
+Xiaomi,MI MAX
+Xiaomi,MI NOTE Pro
+XIAOMI,MI4
+Xiaomi,Mi 4i
+Xiaomi,Mi A2 Lite
+Xiaomi,POCO F1
+Xiaomi,Redmi Note 2
+Xiaomi,Redmi Note 8T
+Xiaomi,Redmi Pro
+XIAOYI,YDXJ 1
+XIAOYI,YDXJ 2
+YAKUMO AG,
+Yakumo GmbH,1210
+YAKUMO,524Z3 Digital Camera
+Yakumo,CamMaster SD 542
+Yakumo,Mega Image XII
+YAKUMO,Mega-Image 410
+"  YAKUMO  OPTICAL CO,LTD",YK-47sx
+YASHICA,EZ UW-5
+YASHICA,TDC5010
+Z Camera,
+Z Camera,Nexus 5X
+ZTE,ZTE
+ZTE,ZTE Aurora 4G LTE
+ZTE,BASE Lutea 2
+ZTE,ZTE-BLADE
+ZTE,ZTE Blade L2
+ZTE,N860
+ZTE,N9810
+ZTE,Orange Monte Carlo
+ZTE,ZTE T790
+ZTE,T90
+ZTE,ZTE V9820
+ZTE,V9C
+ZTE,Z667T
+ZTE,Z797C
+ZTE,Z970
+ZEISS,ZX1

--- a/database/ImageDB.sqlite.sql
+++ b/database/ImageDB.sqlite.sql
@@ -1,5 +1,6 @@
 BEGIN TRANSACTION;
-CREATE TABLE IF NOT EXISTS "Batch" (
+DROP TABLE IF EXISTS "Batch";
+CREATE TABLE "Batch" (
 	"BatchID"	INTEGER,
 	"StartDateTime"	TEXT,
 	"EndDateTime"	TEXT,
@@ -14,14 +15,16 @@ CREATE TABLE IF NOT EXISTS "Batch" (
 	"Comment"	TEXT,
 	PRIMARY KEY("BatchID" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "Collection" (
+DROP TABLE IF EXISTS "Collection";
+CREATE TABLE "Collection" (
 	"CollectionId"	INTEGER,
 	"ImageId"	INTEGER NOT NULL,
 	"CollectionName"	TEXT,
 	"CollectionURI"	TEXT,
 	PRIMARY KEY("CollectionId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "Image" (
+DROP TABLE IF EXISTS "Image";
+CREATE TABLE "Image" (
 	"ImageId"	INTEGER,
 	"PhotoLibraryId"	INTEGER,
 	"Filepath"	TEXT UNIQUE,
@@ -56,7 +59,8 @@ CREATE TABLE IF NOT EXISTS "Image" (
 	"ModifiedBatchId"	INTEGER,
 	PRIMARY KEY("ImageId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "Location" (
+DROP TABLE IF EXISTS "Location";
+CREATE TABLE "Location" (
 	"LocationId"	INTEGER,
 	"LocationIdentifier"	TEXT,
 	"LocationName"	TEXT,
@@ -64,7 +68,8 @@ CREATE TABLE IF NOT EXISTS "Location" (
 	"Longitude"	TEXT,
 	PRIMARY KEY("LocationId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "Log" (
+DROP TABLE IF EXISTS "Log";
+CREATE TABLE "Log" (
 	"LogEntryId"	INTEGER,
 	"Datetime"	TEXT,
 	"BatchID"	INTEGER,
@@ -72,7 +77,8 @@ CREATE TABLE IF NOT EXISTS "Log" (
 	"LogEntry"	TEXT,
 	PRIMARY KEY("LogEntryId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "MetadataHistory" (
+DROP TABLE IF EXISTS "MetadataHistory";
+CREATE TABLE "MetadataHistory" (
 	"HistoryId"	INTEGER,
 	"ImageId"	INTEGER,
 	"Filepath"	TEXT,
@@ -84,18 +90,21 @@ CREATE TABLE IF NOT EXISTS "MetadataHistory" (
 	"StuctMetadata"	TEXT,
 	PRIMARY KEY("HistoryId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "PeopleTag" (
+DROP TABLE IF EXISTS "PeopleTag";
+CREATE TABLE "PeopleTag" (
 	"PeopleTagId"	INTEGER,
 	"PersonName"	TEXT UNIQUE,
 	"FSId"	TEXT,
 	PRIMARY KEY("PeopleTagId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "PhotoLibrary" (
+DROP TABLE IF EXISTS "PhotoLibrary";
+CREATE TABLE "PhotoLibrary" (
 	"PhotoLibraryId"	INTEGER,
 	"Folder"	TEXT NOT NULL,
 	PRIMARY KEY("PhotoLibraryId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "Region" (
+DROP TABLE IF EXISTS "Region";
+CREATE TABLE "Region" (
 	"RegionId"	INTEGER,
 	"ImageId"	INTEGER NOT NULL,
 	"RegionName"	TEXT,
@@ -108,39 +117,68 @@ CREATE TABLE IF NOT EXISTS "Region" (
 	"RegionAreaD"	NUMERIC,
 	PRIMARY KEY("RegionId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "Tag" (
+DROP TABLE IF EXISTS "Tag";
+CREATE TABLE "Tag" (
 	"TagId"	INTEGER,
 	"TagName"	TEXT UNIQUE,
 	"Source"	INTEGER,
 	PRIMARY KEY("TagId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "relationLocation" (
+DROP TABLE IF EXISTS "relationLocation";
+CREATE TABLE "relationLocation" (
 	"LocationRelationId"	INTEGER,
 	"ImageId"	INTEGER,
 	"LocationId"	INTEGER,
 	PRIMARY KEY("LocationRelationId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "relationPeopleTag" (
+DROP TABLE IF EXISTS "relationPeopleTag";
+CREATE TABLE "relationPeopleTag" (
 	"PeopleRelationId"	INTEGER,
 	"ImageId"	INTEGER,
 	"PeopleTagId"	INTEGER,
 	PRIMARY KEY("PeopleRelationId" AUTOINCREMENT)
 );
-CREATE TABLE IF NOT EXISTS "relationTag" (
+DROP TABLE IF EXISTS "relationTag";
+CREATE TABLE "relationTag" (
 	"RelationTagId"	INTEGER,
 	"ImageId"	INTEGER,
 	"TagId"	INTEGER,
 	PRIMARY KEY("RelationTagId" AUTOINCREMENT)
 );
-CREATE VIEW PeopleTagCount
-AS 
-select PeopleTag.PersonName, PeopleTag.PeopleTagID, COUNT(relationPeopleTag.PeopleTagId) AS 'FaceCount' 
-from PeopleTag 
-LEFT JOIN relationPeopleTag on relationPeopleTag.PeopleTagId = PeopleTag.PeopleTagId
-GROUP BY PeopleTag.PersonName
-ORDER BY FaceCount DESC;
+DROP VIEW IF EXISTS "vAlbums";
+CREATE VIEW vAlbums AS
+SELECT
+  Album,
+  MIN(
+    datetime(
+      substr(DateTimeTaken, 1, 10) || ' ' ||
+      printf('%02d', 
+        CASE 
+          WHEN substr(DateTimeTaken, 12, 2) = '12' AND substr(DateTimeTaken, 21, 2) = 'AM' THEN 0
+          WHEN substr(DateTimeTaken, 21, 2) = 'PM' AND substr(DateTimeTaken, 12, 2) != '12' THEN CAST(substr(DateTimeTaken, 12, 2) AS INTEGER) + 12
+          ELSE CAST(substr(DateTimeTaken, 12, 2) AS INTEGER)
+        END
+      ) || substr(DateTimeTaken, 14, 6)
+    )
+  ) AS MinDateTimeTaken,
+  MAX(
+    datetime(
+      substr(DateTimeTaken, 1, 10) || ' ' ||
+      printf('%02d', 
+        CASE 
+          WHEN substr(DateTimeTaken, 12, 2) = '12' AND substr(DateTimeTaken, 21, 2) = 'AM' THEN 0
+          WHEN substr(DateTimeTaken, 21, 2) = 'PM' AND substr(DateTimeTaken, 12, 2) != '12' THEN CAST(substr(DateTimeTaken, 12, 2) AS INTEGER) + 12
+          ELSE CAST(substr(DateTimeTaken, 12, 2) AS INTEGER)
+        END
+      ) || substr(DateTimeTaken, 14, 6)
+    )
+  ) AS MaxDateTimeTaken
+FROM Image
+GROUP BY Album;
+DROP VIEW IF EXISTS "vCollections";
 CREATE VIEW vCollections AS
 SELECT CollectionName, CollectionURI, Count (CollectionId) AS GroupingCount FROM Collection GROUP BY CollectionName, CollectionURI ORDER BY CollectionName, CollectionURI;
+DROP VIEW IF EXISTS "vCreator";
 CREATE VIEW vCreator AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.IFD0:Artist') AS Artist,
@@ -148,8 +186,10 @@ json_extract(Metadata, '$.IPTC:By-line') AS ByLine,
 json_extract(Metadata, '$.XMP-dc:Creator') AS Creator, 
 json_extract(Metadata, '$.XMP-tiff:Artist') AS TiffArtist
 FROM Image;
+DROP VIEW IF EXISTS "vDates";
 CREATE VIEW vDates AS
 SELECT Filepath,DateTimeTaken, DateTimeTakenTimeZone,json_extract(Metadata, '$.ExifIFD:DateTimeOriginal') AS Exif_DateTimeOriginal,json_extract(Metadata, '$.ExifIFD:CreateDate') AS Exif_CreateDate, json_extract(Metadata, '$.IPTC:DateCreated') AS IPTC_DateCreated,json_extract(Metadata, '$.IPTC:TimeCreated') AS IPTC_TimeCreated, json_extract(Metadata, '$.XMP-exif:DateTimeOriginal') AS XMPexif_DateTimeOriginal, json_extract(Metadata, '$.XMP-photoshop:DateCreated') AS XMPphotoshop_DateCreated, Metadata FROM Image;
+DROP VIEW IF EXISTS "vDescriptions";
 CREATE VIEW vDescriptions AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.XMP-dc:Description') AS Description,
@@ -160,20 +200,24 @@ json_extract(Metadata, '$.XMP-tiff:ImageDescription') AS TiffImageDescription,
 json_extract(Metadata, '$.IFD0:XPComment') AS XPComment,
 json_extract(Metadata, '$.IPTC:Headline') AS Headline
 FROM Image;
+DROP VIEW IF EXISTS "vDevices";
 CREATE VIEW vDevices AS
 SELECT ImageId,Filepath,Device, 
 json_extract(Metadata, '$.IFD0:Make') AS Make,
 json_extract(Metadata, '$.IFD0:Model') AS Model 
 FROM Image;
+DROP VIEW IF EXISTS "vDevicesCount";
 CREATE VIEW vDevicesCount AS
 SELECT Device, COUNT(Device) AS DeviceCount FROM vDevices
 GROUP BY Device
 ORDER BY DeviceCount DESC;
+DROP VIEW IF EXISTS "vDuplicateFilenames";
 CREATE VIEW vDuplicateFilenames AS
 SELECT LOWER(Filename) AS Filename, COUNT(*) 
 FROM Image
 GROUP BY LOWER(Filename)
 HAVING COUNT(*) > 1;
+DROP VIEW IF EXISTS "vFileDimensions";
 CREATE VIEW vFileDimensions AS
 SELECT ImageId,Filepath,Filename,
 json_extract(Metadata, '$.File:ImageWidth') AS FileWidth,
@@ -182,12 +226,28 @@ json_extract(Metadata, '$.XMP-mwg-rs:RegionAppliedToDimensionsW') AS RWidth,
 json_extract(Metadata, '$.XMP-mwg-rs:RegionAppliedToDimensionsH') AS RHeight,
 Metadata
 FROM Image;
+DROP VIEW IF EXISTS "vGeotags";
 CREATE VIEW vGeotags AS
 SELECT Location,StateProvince,Country,City,AVG(Latitude) AS Latitude, AVG(Longitude) AS Longitude, Count(ImageId) AS FileCount
 FROM Image
 GROUP BY Location,StateProvince,Country,City;
+DROP VIEW IF EXISTS "vIPTCDigest";
 CREATE VIEW vIPTCDigest AS
 SELECT Filepath, json_extract(Metadata, '$.XMP-photoshop:LegacyIPTCDigest') AS LegacyIPTCDigest,json_extract(Metadata, '$.File:CurrentIPTCDigest') AS CurrentIPTCDigest, Metadata FROM Image WHERE LegacyIPTCDigest IS NOT NULL;
+DROP VIEW IF EXISTS "vImageCameraSettings";
+CREATE VIEW vImageCameraSettings AS
+SELECT ImageId,Filepath,Filename,
+json_extract(Metadata, '$.Composite:Aperture') AS Aperture,
+json_extract(Metadata, '$.Composite:ShutterSpeed') AS ShutterSpeed,
+json_extract(Metadata, '$.ExifIFD:ExposureTime') AS ExposureTime, 
+json_extract(Metadata, '$.ExifIFD:FNumber') AS FNumber,
+json_extract(Metadata, '$.ExifIFD:ExposureProgram') AS ExposureProgram,
+json_extract(Metadata, '$.ExifIFD:ISO') AS ISO,
+json_extract(Metadata, '$.Composite:FocalLength35efl') AS FocalLength35efl,
+json_extract(Metadata, '$.Composite:HyperfocalDistance') AS HyperfocalDistance,
+json_extract(Metadata, '$.Composite:LensID') AS LensID
+FROM Image;
+DROP VIEW IF EXISTS "vLegacyWindowsXP";
 CREATE VIEW vLegacyWindowsXP AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.IFD0:XPTitle') AS XPTitle,
@@ -197,6 +257,7 @@ json_extract(Metadata, '$.IFD0:XPAuthor') AS XPAuthor,
 json_extract(Metadata, '$.IFD0:XPKeywords') AS XPKeywords,
 Metadata
 FROM Image;
+DROP VIEW IF EXISTS "vLegacy_IPTC_IMM";
 CREATE VIEW vLegacy_IPTC_IMM AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.IPTC:ObjectName') AS ObjectName,
@@ -219,6 +280,7 @@ json_extract(Metadata, '$.IPTC:SpecialInstructions') AS SpecialInstructions,
 json_extract(Metadata, '$.IPTC:Category') AS Category,
 Metadata
 FROM Image;
+DROP VIEW IF EXISTS "vMetadataKeys";
 CREATE VIEW vMetadataKeys AS
 WITH json_keys AS (
     SELECT 
@@ -238,6 +300,7 @@ GROUP BY
     json_key
 ORDER BY 
     key_count DESC;
+DROP VIEW IF EXISTS "vMetadataModificationComparison";
 CREATE VIEW vMetadataModificationComparison AS
 WITH PrevMetadata AS (
     SELECT
@@ -272,10 +335,20 @@ WHERE
     AND i.RecordModified IS NOT NULL
 ORDER BY
     i.RecordModified DESC;
+DROP VIEW IF EXISTS "vMissingGeotags";
 CREATE VIEW vMissingGeotags AS
 SELECT Filepath, Latitude,Longitude Location,StateProvince,Country,City
 FROM Image
 WHERE length(Location)=0 AND length(StateProvince)=0 AND length(Country)=0 AND length(City)=0;
+DROP VIEW IF EXISTS "vPeopleTagCount";
+CREATE VIEW vPeopleTagCount
+AS 
+select PeopleTag.PersonName, PeopleTag.PeopleTagID, COUNT(relationPeopleTag.PeopleTagId) AS 'FaceCount' 
+from PeopleTag 
+LEFT JOIN relationPeopleTag on relationPeopleTag.PeopleTagId = PeopleTag.PeopleTagId
+GROUP BY PeopleTag.PersonName
+ORDER BY FaceCount DESC;
+DROP VIEW IF EXISTS "vPeopleTagRegionCountDiff";
 CREATE VIEW vPeopleTagRegionCountDiff AS
 SELECT i.ImageId,i.Filepath,i.Filename, i.StuctMetadata, peopleTagCount, regionCount
 FROM Image i
@@ -291,19 +364,24 @@ LEFT JOIN (
 ) r ON i.ImageId = r.ImageId
 WHERE IFNULL(rpt.peopleTagCount, 0) != IFNULL(r.regionCount, 0)
 ORDER BY i.ImageId;
+DROP VIEW IF EXISTS "vPhotoDates";
 CREATE VIEW vPhotoDates AS
 SELECT Filepath,DateTimeTaken, DateTimeTakenTimeZone,json_extract(Metadata, '$.ExifIFD:DateTimeOriginal') AS Exif_DateTimeOriginal,json_extract(Metadata, '$.ExifIFD:CreateDate') AS Exif_CreateDate, json_extract(Metadata, '$.IPTC:DateCreated') AS IPTC_DateCreated,json_extract(Metadata, '$.IPTC:TimeCreated') AS IPTC_TimeCreated, json_extract(Metadata, '$.XMP-exif:DateTimeOriginal') AS XMPexif_DateTimeOriginal, json_extract(Metadata, '$.XMP-photoshop:DateCreated') AS XMPphotoshop_DateCreated, Metadata FROM Image;
+DROP VIEW IF EXISTS "vRatingCounts";
 CREATE VIEW vRatingCounts AS
 select Rating, Count(ImageId) As ImageCount from Image
 GROUP BY Rating;
+DROP VIEW IF EXISTS "vRecentlyModified";
 CREATE VIEW vRecentlyModified AS
 SELECT Filepath,FileModifiedDate, Metadata
 FROM Image
 ORDER BY FileModifiedDate DESC;
+DROP VIEW IF EXISTS "vRegionMismatch";
 CREATE VIEW vRegionMismatch AS
 SELECT *
 FROM vFileDimensions
 WHERE (FileWidth<>RWidth OR FileHeight<>RHeight) AND (FileWidth<>RHeight OR FileHeight<>RWidth);
+DROP VIEW IF EXISTS "vRights";
 CREATE VIEW vRights AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.IFD0:Copyright') AS Copyright,
@@ -311,6 +389,7 @@ json_extract(Metadata, '$.IPTC:CopyrightNotice') AS CopyrightNotice,
 json_extract(Metadata, '$.XMP-dc:Rights') AS Rights,
 json_extract(Metadata, '$.XMP-tiff:Copyright') AS TiffCopyright
 FROM Image;
+DROP VIEW IF EXISTS "vSaveMetadataDotOrg";
 CREATE VIEW vSaveMetadataDotOrg AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.XMP-dc:Title') AS Title,
@@ -324,12 +403,14 @@ json_extract(Metadata, '$.XMP-iptcExt:LocationShownCountryName') AS CountryName,
 json_extract(Metadata, '$.XMP-iptcExt:LocationShownLocationId') AS LocationId,
 Metadata
 FROM Image;
+DROP VIEW IF EXISTS "vTitles";
 CREATE VIEW vTitles AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.XMP-dc:Title') AS Title,
 json_extract(Metadata, '$.IPTC:ObjectName') AS ObjectName, 
 json_extract(Metadata, '$.IFD0:XPTitle') AS XPTitle
 FROM Image;
+DROP VIEW IF EXISTS "vWeatherTags";
 CREATE VIEW vWeatherTags AS
 SELECT ImageId,Filepath, 
 json_extract(Metadata, '$.ExifIFD:AmbientTemperature') AS AmbientTemperature,
@@ -337,13 +418,16 @@ json_extract(Metadata, '$.ExifIFD:Humidity') AS Humidity,
 json_extract(Metadata, '$.ExifIFD:Pressure') AS Pressure,
 Metadata
 FROM Image;
-CREATE INDEX IF NOT EXISTS "idx_image_filepath" ON "Image" (
+DROP INDEX IF EXISTS "idx_image_filepath";
+CREATE INDEX "idx_image_filepath" ON "Image" (
 	"Filepath"
 );
-CREATE INDEX IF NOT EXISTS "idx_image_record_modified" ON "Image" (
+DROP INDEX IF EXISTS "idx_image_record_modified";
+CREATE INDEX "idx_image_record_modified" ON "Image" (
 	"RecordModified"
 );
-CREATE INDEX IF NOT EXISTS "idx_metadata_history_image_id" ON "MetadataHistory" (
+DROP INDEX IF EXISTS "idx_metadata_history_image_id";
+CREATE INDEX "idx_metadata_history_image_id" ON "MetadataHistory" (
 	"ImageId"
 );
 COMMIT;


### PR DESCRIPTION
- Improved DeviceHelper.cs which which ormalizes camera/device maker and model strings into a consistent, human-friendly Device name used to populate de device field. (e.g., combine/normalize Make + Model into "Apple iPhone 11 Pro Max" or "Canon PowerShot G7").
- Included Sample_DeviceList.csv which contains sample Exif Make and Model data, file used for testing DeviceHelper.cs
- Added additional views to database SQL script.
- Added more comments to code.